### PR TITLE
Dolly pro: 修复重复劫持导致的加载失败bug；修复新旧多莉不兼容的bug

### DIFF
--- a/DollyPro/dollytest.js
+++ b/DollyPro/dollytest.js
@@ -286,7 +286,7 @@ class dollyProExtension {
         'witCat.dollyPro.defaultValue.HP': '生命值',
         'witCat.dollyPro.defaultValue.direction': '方向',
         'witCat.dollyPro.defaultValue.enemy': '敌人',
-        'witCat.dollyPro.defaultValue.player': '玩家',
+        'witCat.dollyPro.defaultValue.player': 'ID',
         'witCat.dollyPro.defaultValue.presetJSON':
           '\'{"名称":"普通士兵","生命值":100,"阵营":"红色"}\'',
         'witCat.dollyPro.menu.addOrRemove.add': '加入',
@@ -466,7 +466,7 @@ class dollyProExtension {
         'witCat.dollyPro.defaultValue.HP': 'health point',
         'witCat.dollyPro.defaultValue.direction': 'direction',
         'witCat.dollyPro.defaultValue.enemy': 'enemy',
-        'witCat.dollyPro.defaultValue.player': 'player',
+        'witCat.dollyPro.defaultValue.player': 'ID',
         'witCat.dollyPro.defaultValue.presetJSON':
           '\'{"name":"common soldier ","HP":100,"team":"red"}\'',
         'witCat.dollyPro.menu.cloneProperty.IDList': 'lists',
@@ -531,7 +531,7 @@ class dollyProExtension {
       name: this.formatMessage('name'),
       menuIconURI: icon,
       blockIconURI: icon,
-      color1: '#FA8D0D',
+      color1: '#FF9922',
       docsURI: this.formatMessage('url'),
       blocks: [
         // 按钮：显示不常用积木
@@ -714,7 +714,7 @@ class dollyProExtension {
             },
             VALUE: {
               type: ArgumentType.STRING,
-              defaultValue: this.formatMessage('defaultValue.enemy'),
+              defaultValue: 'ID', // this.formatMessage('defaultValue.enemy'),
             },
             MSG: {
               type: ArgumentType.STRING,
@@ -828,6 +828,7 @@ class dollyProExtension {
         {
           opcode: 'getJustCreatedCloneID',
           blockType: BlockType.REPORTER,
+          disableMonitor: true,
           text: this.formatMessage('block.getJustCreatedCloneID'),
         },
         {
@@ -1154,7 +1155,7 @@ class dollyProExtension {
             },
             VALUE: {
               type: ArgumentType.STRING,
-              defaultValue: this.formatMessage('defaultValue.enemy'),
+              defaultValue: 'ID', // this.formatMessage('defaultValue.enemy'),
             },
           },
         },
@@ -1175,7 +1176,7 @@ class dollyProExtension {
             },
             VALUE: {
               type: ArgumentType.STRING,
-              defaultValue: this.formatMessage('defaultValue.enemy'),
+              defaultValue: 'ID2', // this.formatMessage('defaultValue.enemy'),
             },
           },
         },
@@ -1246,7 +1247,7 @@ class dollyProExtension {
             },
             VALUE: {
               type: ArgumentType.STRING,
-              defaultValue: this.formatMessage('defaultValue.enemy'),
+              defaultValue: 'ID', // this.formatMessage('defaultValue.enemy'),
             },
           },
         },
@@ -1293,11 +1294,11 @@ class dollyProExtension {
           arguments: {
             ID1: {
               type: ArgumentType.STRING,
-              defaultValue: this.formatMessage('defaultValue.player'),
+              defaultValue: 'ID', // this.formatMessage('defaultValue.player'),
             },
             ID2: {
               type: ArgumentType.STRING,
-              defaultValue: this.formatMessage('defaultValue.enemy'),
+              defaultValue: 'ID2', // this.formatMessage('defaultValue.enemy'),
             },
             MENU: {
               type: ArgumentType.STRING,

--- a/DollyPro/dollytest.js
+++ b/DollyPro/dollytest.js
@@ -2034,8 +2034,8 @@ class dollyProExtension {
     // 狠狠注入多莉数据（doge）
     target.DollyPro = {
       ID: this.generateTargetID(target, ID), // 克隆体多莉ID (不指定则默认为原版target.id)
-      extraData: {}, // 克隆体的 KV 数据
-      isInGroup: {}, // 记录是否在某个组，例如 isInGroup["敌人"] == true
+      extraData: Object.create(null), // 克隆体的 KV 数据
+      isInGroup: Object.create(null), // 记录是否在某个组，例如 isInGroup["敌人"] == true
     };
     // 加入ID映射表
     this.IDtoTargets[target.DollyPro.ID] = target;
@@ -2076,6 +2076,8 @@ class dollyProExtension {
   processCloneBeforeCreation(target) {
     // 读取预设KV数据
     target.DollyPro.extraData = { ...this.clonePresetData };
+    // 原型设为 null
+    Object.setPrototypeOf(target.DollyPro.extraData, null);
     // 加入预设分组
     const ID = this.getIDOfTarget(target);
 

--- a/DollyPro/dollytest.js
+++ b/DollyPro/dollytest.js
@@ -1962,7 +1962,7 @@ class dollyProExtension {
    * （如果之前没有劫持）劫持obj对象的方法
    * @param {*} obj
    * @param {string} funName 方法名
-   * @param {Function} newFun 注入的方法
+   * @param {Function} newFun 注入的方法(形如(origFun, 其他参数)=>{...})
    */
   tryHackedFunction(obj, funName, newFun) {
     if (!obj.dollyProOrigFun) {
@@ -1971,6 +1971,7 @@ class dollyProExtension {
     }
     if (!obj.dollyProOrigFun[funName]) {
       // 记录原函数
+      // eslint-disable-next-line no-param-reassign
       obj.dollyProOrigFun[funName] = obj[funName];
     }
     const origFun = obj.dollyProOrigFun[funName];
@@ -2805,10 +2806,10 @@ class dollyProExtension {
   importArrayIntoScratchList(array, OP, LIST, util) {
     if (LIST === 'empty') return;
     let list = util.target.lookupVariableById(LIST);
-    if (!list) return;
-    list = util.target.lookupVariableByNameAndType(LIST, 'list');
-    if (!list) return;
-
+    if (!list) {
+      list = util.target.lookupVariableByNameAndType(LIST, 'list');
+      if (!list) return;
+    }
     if (OP === 'replace') {
       if (array) {
         list.value = [...array];

--- a/DollyPro/dollytest.js
+++ b/DollyPro/dollytest.js
@@ -1,187 +1,188 @@
-const BlockType = {
-  BOOLEAN: 'Boolean',
-  BUTTON: 'button',
-  COMMAND: 'command',
-  CONDITIONAL: 'conditional',
-  EVENT: 'event',
-  HAT: 'hat',
-  LOOP: 'loop',
-  REPORTER: 'reporter',
-};
+/* eslint-disable class-methods-use-this */
+/* eslint no-param-reassign: [
+  "error", {
+    "props": true,
+    "ignorePropertyModificationsForRegex": ["^target"] }]
+*/
 
-const ArgumentType = {
-  ANGLE: 'angle',
-  BOOLEAN: 'Boolean',
-  COLOR: 'color',
-  NUMBER: 'number',
-  STRING: 'string',
-  MATRIX: 'matrix',
-  NOTE: 'note',
-  IMAGE: 'image',
-};
-
-const TargetType = {
-  STAGE: 'stage',
-  SPRITE: 'sprite',
-};
-
-import Cast from './cast.js';
-// import cover from './assets/cover.png'
-// import icon from './assets/icon.svg'
+const { Scratch } = window;
+const {
+  BlockType, ArgumentType, TargetType, Cast,
+} = Scratch;
 
 const extensionNS = 'witCat';
 const extensionId = `${extensionNS}.dollyPro`;
 
-const cover =
-  'https://m.ccw.site/user_projects_assets/8192f42de3c3020a10cd58bfd617d5e3.png';
-const icon =
-  'data:image/svg+xml;base64,PHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHdpZHRoPSIxMjAuNSIgaGVpZ2h0PSIxMjAuNSIgdmlld0JveD0iMCwwLDEyMC41LDEyMC41Ij48ZyB0cmFuc2Zvcm09InRyYW5zbGF0ZSgtMjU5Ljc1LC0xMTkuNzUpIj48ZyBkYXRhLXBhcGVyLWRhdGE9InsmcXVvdDtpc1BhaW50aW5nTGF5ZXImcXVvdDs6dHJ1ZX0iIGZpbGwtcnVsZT0ibm9uemVybyIgc3Ryb2tlLWxpbmVjYXA9ImJ1dHQiIHN0cm9rZS1saW5lam9pbj0ibWl0ZXIiIHN0cm9rZS1taXRlcmxpbWl0PSIxMCIgc3Ryb2tlLWRhc2hhcnJheT0iIiBzdHJva2UtZGFzaG9mZnNldD0iMCIgc3R5bGU9Im1peC1ibGVuZC1tb2RlOiBub3JtYWwiPjxwYXRoIGQ9Ik0yNzYuOTY2NDIsMTU2LjIzNjAxYy0xLjYyNDgsLTMuNTc0NiAtMC45Njg4LC0xMC4xOTc5IDMuODk5NSwtMTIuMDIzNWM1LjE5OTQsLTEuOTQ5OCA3LjQ3NDEsLTMuNTc0NiAxNy44NzI5LDQuMjI0NGM4LjMxOSw2LjIzOTMgOS41MzIyLDEwLjYxNTQgOS4wOTg5LDEyLjAyMzZsLTUuODQ5Myw2LjE3NDJjLTAuNDMzMywtMS4yOTk4IC0zLjExOTYsLTQuMzU0NCAtMTAuMzk4OCwtNi4xNzQyYy05LjA5ODksLTIuMjc0NyAtMTIuOTk4NCwtMC42NDk5IC0xNC42MjMyLC00LjIyNDV6IiBmaWxsPSIjZmZmZmZmIiBzdHJva2U9Im5vbmUiIHN0cm9rZS13aWR0aD0iMSIvPjxwYXRoIGQ9Ik0zNjcuOTU1NTQsMTQ5LjQzNjkzYy0yLjYsMi45MjQ1IC0zLjI1LDcuNzk5MSAtMTAuNzI0LDcuNzk5MWMtNS45NzkxLDAgLTEwLjI5MDIsMi44MTYzIC0xMi42NzMzLDUuMTk5M2wtNi44MjQxLC01LjE5OTNjMC44NjY1LC0yLjM4MyA0LjQ4NDQsLTguMTIzOSAxMi4wMjM1LC0xMi4wMjM1YzkuNDIzOSwtNC44NzQ2IDIwLjc5NzksMS4yOTk5IDE4LjE5NzksNC4yMjQ0eiIgZmlsbD0iI2ZmZmZmZiIgc3Ryb2tlPSJub25lIiBzdHJva2Utd2lkdGg9IjEiLz48cGF0aCBkPSJNMjc1LjM0MTY0LDE4OS4wNTcwMWM0LjY3OTUsLTYuMjM5MiAxOC4xOTc4LC04Ljg4MjIgMjQuMzcyMSwtOS40MjM4YzAsLTIuMjc0OCAxLjAzOTgsLTguMjU0IDUuMTk5MywtMTMuOTczNGM1LjE5OTQsLTcuMTQ5MSA5LjA5ODksLTEyLjk5ODQgMjYuNjQ2OCwtMTAuMzk4N2MxNy41NDc5LDIuNTk5NyAxNy4yMjI5LDIwLjE0NzYgMTkuMTcyNywyNC4zNzIxYzEuOTQ5OCw0LjIyNDQgMC45NzQ5LDIxLjQ0NzQgLTcuNzk5MSwyOC41OTY1Yy04Ljc3MzksNy4xNDkyIC0yNi4zMjE4LDguNDQ5MiAtMzguMDIwNCw4LjEyNDJjLTExLjY5ODYsLTAuMzI1IC0yMS4xMjI0LC01LjE5OTUgLTI2Ljk3MTcsLTguMTI0MmMtNS44NDkzLC0yLjkyNDYgLTguNDQ5LC0xMS4zNzM2IC0yLjU5OTcsLTE5LjE3Mjd6IiBmaWxsPSIjZmZmZmZmIiBzdHJva2U9Im5vbmUiIHN0cm9rZS13aWR0aD0iMSIvPjxwYXRoIGQ9Ik0zMDcuODM3NywxNjEuMDYxNjZjMC40MzMzLC0xLjQwODIgLTAuNzc5OSwtNS43ODQzIC05LjA5ODksLTEyLjAyMzZjLTEwLjM5ODgsLTcuNzk5IC0xMi42NzM1LC02LjE3NDIgLTE3Ljg3MjksLTQuMjI0NGMtNC44NjgzLDEuODI1NiAtNS41MjQzLDguNDQ4OSAtMy44OTk1LDEyLjAyMzVjMS42MjQ4LDMuNTc0NiA1LjUyNDMsMS45NDk4IDE0LjYyMzIsNC4yMjQ1YzcuMjc5MiwxLjgxOTggOS45NjU1LDQuODc0NCAxMC4zOTg4LDYuMTc0MnpNMzQ0LjU1ODIyLDE2Mi4wMzY0MWMyLjM4MzEsLTIuMzgzIDYuNjk0MiwtNS4xOTkzIDEyLjY3MzMsLTUuMTk5M2M3LjQ3NCwwIDguMTI0LC00Ljg3NDYgMTAuNzI0LC03Ljc5OTFjMi42LC0yLjkyNDUgLTguNzc0LC05LjA5OSAtMTguMTk3OSwtNC4yMjQ0Yy03LjUzOTEsMy44OTk2IC0xMS4xNTcsOS42NDA1IC0xMi4wMjM1LDEyLjAyMzV6TTMwNC45MTMsMTY2LjI2MDhjNS4xOTk0LC03LjE0OTEgOS4wOTg5LC0xMi45OTg0IDI2LjY0NjgsLTEwLjM5ODdjMTcuNTQ3OSwyLjU5OTcgMTcuMjIyOSwyMC4xNDc2IDE5LjE3MjcsMjQuMzcyMWMxLjk0OTgsNC4yMjQ0IDAuOTc0OSwyMS40NDc0IC03Ljc5OTEsMjguNTk2NWMtOC43NzM5LDcuMTQ5MiAtMjYuMzIxOCw4LjQ0OTIgLTM4LjAyMDQsOC4xMjQyYy0xMS42OTg2LC0wLjMyNSAtMjEuMTIyNCwtNS4xOTk1IC0yNi45NzE3LC04LjEyNDJjLTUuODQ5MywtMi45MjQ2IC04LjQ0OSwtMTEuMzczNiAtMi41OTk3LC0xOS4xNzI3YzQuNjc5NSwtNi4yMzkyIDE4LjE5NzgsLTguODgyMiAyNC4zNzIxLC05LjQyMzhjMCwtMi4yNzQ4IDEuMDM5OCwtOC4yNTQgNS4xOTkzLC0xMy45NzM0eiIgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjMDAwMDAwIiBzdHJva2Utd2lkdGg9IjUiLz48cGF0aCBkPSJNMzM4LjkwMzEsMTk1LjcxMDg5YzAsMCAtNy45NTI2Niw0Ljg3ODc0IC0xMy42MjA0Niw2LjcxMDgxYy02LjMyNDY2LDIuMDQ0NCAtMjIuNTczNDQsNC45ODg1OSAtMjIuNTczNDQsNC45ODg1OSIgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjMDAwMDAwIiBzdHJva2Utd2lkdGg9IjUiLz48Zz48cGF0aCBkPSJNMzE1LjczNzM4LDE4NS40NDg0MmMtMi41MDQ3NCwyLjAwNjggLTE1LjE2ODA0LC0yLjQ3MzY3IC0xNS4xNjgwNCwtMi40NzM2N2MwLDAgLTguMDE3MDEsNy45NjIzNCAtMTEuNjM3OTMsNi45ODQwNGMtMy42MjMzLC0wLjk3NzY4IC0xLjE4MjkyLC0xMC40NDU0NSAtMS4xODI5MiwtMTAuNDQ1NDVjMCwwIC0xMy43NjMwNiwtMi42NTU3MSAtMTMuNDk1MTUsLTUuMjY4MDdjMC4yNjcwNCwtMi42MTQxIDE0LjQ0MDYyLC0zLjk4MjA1IDE0LjQ0MDYyLC0zLjk4MjA1YzAsMCAtMC40OTExNiwtOS42MDEzOCAzLjI5NDQxLC0xMC4yNDAxMWMzLjc5MTM4LC0wLjYzODI3IDEwLjExMjI4LDcuOTg0MSAxMC4xMTIyOCw3Ljk4NDFjMCwwIDEzLjQ1OSwtMy4yODA2IDE1LjUzMDI0LC0xLjA1OTY1YzIuMDc3ODMsMi4yMTc2MyAtOC4xOTExNyw4LjkxNjQxIC04LjE5MTE3LDguOTE2NDFjMCwwIDguODA5ODgsNy41NzU5NyA2LjI5NzY0LDkuNTg0NXoiIGZpbGw9IiMwMDAwMDAiIHN0cm9rZT0ibm9uZSIgc3Ryb2tlLXdpZHRoPSIwIi8+PHBhdGggZD0iTTI4OC4yMzgxMywxODQuMTU3NjJsLTEuNDM0OCwtNC45OTI3NWwxMS4xMjI1OSwtMTcuNDExOTFsMy4xMDQwNywyLjY2MzM3YzAsMCAtMTIuNzYyMDEsMTkuNzM1MTIgLTEyLjc5MTg1LDE5Ljc0MTI5eiIgZmlsbD0iI2ZmZmZmZiIgc3Ryb2tlPSJub25lIiBzdHJva2Utd2lkdGg9IjEiLz48cGF0aCBkPSJNMzE1LjczNzM4LDE4NS40NDg0MmMtMi41MDQ3NCwyLjAwNjggLTE1LjE2ODA0LC0yLjQ3MzY3IC0xNS4xNjgwNCwtMi40NzM2N2MwLDAgLTguMDE3MDEsNy45NjIzNCAtMTEuNjM3OTMsNi45ODQwNGMtMy42MjMzLC0wLjk3NzY4IC0xLjE4MjkyLC0xMC40NDU0NSAtMS4xODI5MiwtMTAuNDQ1NDVjMCwwIC0xMy43NjMwNiwtMi42NTU3MSAtMTMuNDk1MTUsLTUuMjY4MDdjMC4yNjcwNCwtMi42MTQxIDE0LjQ0MDYyLC0zLjk4MjA1IDE0LjQ0MDYyLC0zLjk4MjA1YzAsMCAtMC40OTExNiwtOS42MDEzOCAzLjI5NDQxLC0xMC4yNDAxMWMzLjc5MTM4LC0wLjYzODI3IDEwLjExMjI4LDcuOTg0MSAxMC4xMTIyOCw3Ljk4NDFjMCwwIDEzLjQ1OSwtMy4yODA2IDE1LjUzMDI0LC0xLjA1OTY1YzIuMDc3ODMsMi4yMTc2MyAtOC4xOTExNyw4LjkxNjQxIC04LjE5MTE3LDguOTE2NDFjMCwwIDguODA5ODgsNy41NzU5NyA2LjI5NzY0LDkuNTg0NXoiIGZpbGw9Im5vbmUiIHN0cm9rZS1vcGFjaXR5PSIwLjYyNzQ1IiBzdHJva2U9IiNmZmRjMDAiIHN0cm9rZS13aWR0aD0iMi41Ii8+PC9nPjxnPjxwYXRoIGQ9Ik0zNTQuNjEyODEsMTg1LjA0MDU4Yy0yLjUxODg1LDEuODY5ODYgLTE1LjAyMTksLTIuNDI4MDYgLTE1LjAyMTksLTIuNDI4MDZjMCwwIC04LjA4NjU3LDcuNDMxOTIgLTExLjY2NjQ4LDYuNDg3NzFjLTMuNTgyMjcsLTAuOTQzNjQgLTEuMDA5MTMsLTkuODI4NTcgLTEuMDA5MTMsLTkuODI4NTdjMCwwIC0xMy42MjM5NCwtMi41ODk3MyAtMTMuMzE2NTcsLTUuMDQ0YzAuMzA2NTQsLTIuNDU1OTEgMTQuNDAxODUsLTMuNjQ2MzkgMTQuNDAxODUsLTMuNjQ2MzljMCwwIC0wLjMzNTY3LC05LjAzMDM0IDMuNDMzMzMsLTkuNjA1MzFjMy43NzQ3OCwtMC41NzQ1MiA5LjkxNDU2LDcuNTc0NzMgOS45MTQ1Niw3LjU3NDczYzAsMCAxMy40MTYwMywtMi45OTM1MiAxNS40Mzc0OSwtMC44OTE0NmMyLjAyODA1LDIuMDk4OTggLTguMjc0NTksOC4zMjc3NCAtOC4yNzQ1OSw4LjMyNzc0YzAsMCA4LjYyNzc5LDcuMTgyMjMgNi4xMDE0Niw5LjA1MzY1eiIgZmlsbD0iIzAwMDAwMCIgc3Ryb2tlPSJub25lIiBzdHJva2Utd2lkdGg9IjAiLz48cGF0aCBkPSJNMzI3LjE4MDA0LDE4NC4xNTg3MWwtMS4zNDU2MiwtNC43MDM3NmwxMS4zMTk4NywtMTYuMjk1MjRsMy4wNDAwMiwyLjUyNTAxYzAsMCAtMTIuOTg0NTEsMTguNDY4NCAtMTMuMDE0MjYsMTguNDc0MDF6IiBmaWxsPSIjZmZmZmZmIiBzdHJva2U9Im5vbmUiIHN0cm9rZS13aWR0aD0iMSIvPjxwYXRoIGQ9Ik0zNTQuNjEyODEsMTg1LjA0MDU4Yy0yLjUxODg1LDEuODY5ODYgLTE1LjAyMTksLTIuNDI4MDYgLTE1LjAyMTksLTIuNDI4MDZjMCwwIC04LjA4NjU3LDcuNDMxOTIgLTExLjY2NjQ4LDYuNDg3NzFjLTMuNTgyMjcsLTAuOTQzNjQgLTEuMDA5MTMsLTkuODI4NTcgLTEuMDA5MTMsLTkuODI4NTdjMCwwIC0xMy42MjM5NCwtMi41ODk3MyAtMTMuMzE2NTcsLTUuMDQ0YzAuMzA2NTQsLTIuNDU1OTEgMTQuNDAxODUsLTMuNjQ2MzkgMTQuNDAxODUsLTMuNjQ2MzljMCwwIC0wLjMzNTY3LC05LjAzMDM0IDMuNDMzMzMsLTkuNjA1MzFjMy43NzQ3OCwtMC41NzQ1MiA5LjkxNDU2LDcuNTc0NzMgOS45MTQ1Niw3LjU3NDczYzAsMCAxMy40MTYwMywtMi45OTM1MiAxNS40Mzc0OSwtMC44OTE0NmMyLjAyODA1LDIuMDk4OTggLTguMjc0NTksOC4zMjc3NCAtOC4yNzQ1OSw4LjMyNzc0YzAsMCA4LjYyNzc5LDcuMTgyMjMgNi4xMDE0Niw5LjA1MzY1eiIgZmlsbD0ibm9uZSIgc3Ryb2tlLW9wYWNpdHk9IjAuNjI3NDUiIHN0cm9rZT0iI2ZmZGMwMCIgc3Ryb2tlLXdpZHRoPSIyLjUiLz48L2c+PHBhdGggZD0iTTI1OS43NSwyNDAuMjV2LTEyMC41aDEyMC41djEyMC41eiIgZmlsbD0ibm9uZSIgc3Ryb2tlPSJub25lIiBzdHJva2Utd2lkdGg9IjAiLz48L2c+PC9nPjwvc3ZnPg==';
+/** 保存扩展配置的舞台注释的Id */
+const EXT_CONFIG_COMMENT_ID = '_ArkosExtensionConfig_';
+
+const cover = 'https://m.ccw.site/user_projects_assets/8192f42de3c3020a10cd58bfd617d5e3.png';
+const icon = 'data:image/svg+xml;base64,PHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHdpZHRoPSIxMjAuNSIgaGVpZ2h0PSIxMjAuNSIgdmlld0JveD0iMCwwLDEyMC41LDEyMC41Ij48ZyB0cmFuc2Zvcm09InRyYW5zbGF0ZSgtMjU5Ljc1LC0xMTkuNzUpIj48ZyBkYXRhLXBhcGVyLWRhdGE9InsmcXVvdDtpc1BhaW50aW5nTGF5ZXImcXVvdDs6dHJ1ZX0iIGZpbGwtcnVsZT0ibm9uemVybyIgc3Ryb2tlLWxpbmVjYXA9ImJ1dHQiIHN0cm9rZS1saW5lam9pbj0ibWl0ZXIiIHN0cm9rZS1taXRlcmxpbWl0PSIxMCIgc3Ryb2tlLWRhc2hhcnJheT0iIiBzdHJva2UtZGFzaG9mZnNldD0iMCIgc3R5bGU9Im1peC1ibGVuZC1tb2RlOiBub3JtYWwiPjxwYXRoIGQ9Ik0yNzYuOTY2NDIsMTU2LjIzNjAxYy0xLjYyNDgsLTMuNTc0NiAtMC45Njg4LC0xMC4xOTc5IDMuODk5NSwtMTIuMDIzNWM1LjE5OTQsLTEuOTQ5OCA3LjQ3NDEsLTMuNTc0NiAxNy44NzI5LDQuMjI0NGM4LjMxOSw2LjIzOTMgOS41MzIyLDEwLjYxNTQgOS4wOTg5LDEyLjAyMzZsLTUuODQ5Myw2LjE3NDJjLTAuNDMzMywtMS4yOTk4IC0zLjExOTYsLTQuMzU0NCAtMTAuMzk4OCwtNi4xNzQyYy05LjA5ODksLTIuMjc0NyAtMTIuOTk4NCwtMC42NDk5IC0xNC42MjMyLC00LjIyNDV6IiBmaWxsPSIjZmZmZmZmIiBzdHJva2U9Im5vbmUiIHN0cm9rZS13aWR0aD0iMSIvPjxwYXRoIGQ9Ik0zNjcuOTU1NTQsMTQ5LjQzNjkzYy0yLjYsMi45MjQ1IC0zLjI1LDcuNzk5MSAtMTAuNzI0LDcuNzk5MWMtNS45NzkxLDAgLTEwLjI5MDIsMi44MTYzIC0xMi42NzMzLDUuMTk5M2wtNi44MjQxLC01LjE5OTNjMC44NjY1LC0yLjM4MyA0LjQ4NDQsLTguMTIzOSAxMi4wMjM1LC0xMi4wMjM1YzkuNDIzOSwtNC44NzQ2IDIwLjc5NzksMS4yOTk5IDE4LjE5NzksNC4yMjQ0eiIgZmlsbD0iI2ZmZmZmZiIgc3Ryb2tlPSJub25lIiBzdHJva2Utd2lkdGg9IjEiLz48cGF0aCBkPSJNMjc1LjM0MTY0LDE4OS4wNTcwMWM0LjY3OTUsLTYuMjM5MiAxOC4xOTc4LC04Ljg4MjIgMjQuMzcyMSwtOS40MjM4YzAsLTIuMjc0OCAxLjAzOTgsLTguMjU0IDUuMTk5MywtMTMuOTczNGM1LjE5OTQsLTcuMTQ5MSA5LjA5ODksLTEyLjk5ODQgMjYuNjQ2OCwtMTAuMzk4N2MxNy41NDc5LDIuNTk5NyAxNy4yMjI5LDIwLjE0NzYgMTkuMTcyNywyNC4zNzIxYzEuOTQ5OCw0LjIyNDQgMC45NzQ5LDIxLjQ0NzQgLTcuNzk5MSwyOC41OTY1Yy04Ljc3MzksNy4xNDkyIC0yNi4zMjE4LDguNDQ5MiAtMzguMDIwNCw4LjEyNDJjLTExLjY5ODYsLTAuMzI1IC0yMS4xMjI0LC01LjE5OTUgLTI2Ljk3MTcsLTguMTI0MmMtNS44NDkzLC0yLjkyNDYgLTguNDQ5LC0xMS4zNzM2IC0yLjU5OTcsLTE5LjE3Mjd6IiBmaWxsPSIjZmZmZmZmIiBzdHJva2U9Im5vbmUiIHN0cm9rZS13aWR0aD0iMSIvPjxwYXRoIGQ9Ik0zMDcuODM3NywxNjEuMDYxNjZjMC40MzMzLC0xLjQwODIgLTAuNzc5OSwtNS43ODQzIC05LjA5ODksLTEyLjAyMzZjLTEwLjM5ODgsLTcuNzk5IC0xMi42NzM1LC02LjE3NDIgLTE3Ljg3MjksLTQuMjI0NGMtNC44NjgzLDEuODI1NiAtNS41MjQzLDguNDQ4OSAtMy44OTk1LDEyLjAyMzVjMS42MjQ4LDMuNTc0NiA1LjUyNDMsMS45NDk4IDE0LjYyMzIsNC4yMjQ1YzcuMjc5MiwxLjgxOTggOS45NjU1LDQuODc0NCAxMC4zOTg4LDYuMTc0MnpNMzQ0LjU1ODIyLDE2Mi4wMzY0MWMyLjM4MzEsLTIuMzgzIDYuNjk0MiwtNS4xOTkzIDEyLjY3MzMsLTUuMTk5M2M3LjQ3NCwwIDguMTI0LC00Ljg3NDYgMTAuNzI0LC03Ljc5OTFjMi42LC0yLjkyNDUgLTguNzc0LC05LjA5OSAtMTguMTk3OSwtNC4yMjQ0Yy03LjUzOTEsMy44OTk2IC0xMS4xNTcsOS42NDA1IC0xMi4wMjM1LDEyLjAyMzV6TTMwNC45MTMsMTY2LjI2MDhjNS4xOTk0LC03LjE0OTEgOS4wOTg5LC0xMi45OTg0IDI2LjY0NjgsLTEwLjM5ODdjMTcuNTQ3OSwyLjU5OTcgMTcuMjIyOSwyMC4xNDc2IDE5LjE3MjcsMjQuMzcyMWMxLjk0OTgsNC4yMjQ0IDAuOTc0OSwyMS40NDc0IC03Ljc5OTEsMjguNTk2NWMtOC43NzM5LDcuMTQ5MiAtMjYuMzIxOCw4LjQ0OTIgLTM4LjAyMDQsOC4xMjQyYy0xMS42OTg2LC0wLjMyNSAtMjEuMTIyNCwtNS4xOTk1IC0yNi45NzE3LC04LjEyNDJjLTUuODQ5MywtMi45MjQ2IC04LjQ0OSwtMTEuMzczNiAtMi41OTk3LC0xOS4xNzI3YzQuNjc5NSwtNi4yMzkyIDE4LjE5NzgsLTguODgyMiAyNC4zNzIxLC05LjQyMzhjMCwtMi4yNzQ4IDEuMDM5OCwtOC4yNTQgNS4xOTkzLC0xMy45NzM0eiIgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjMDAwMDAwIiBzdHJva2Utd2lkdGg9IjUiLz48cGF0aCBkPSJNMzM4LjkwMzEsMTk1LjcxMDg5YzAsMCAtNy45NTI2Niw0Ljg3ODc0IC0xMy42MjA0Niw2LjcxMDgxYy02LjMyNDY2LDIuMDQ0NCAtMjIuNTczNDQsNC45ODg1OSAtMjIuNTczNDQsNC45ODg1OSIgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjMDAwMDAwIiBzdHJva2Utd2lkdGg9IjUiLz48Zz48cGF0aCBkPSJNMzE1LjczNzM4LDE4NS40NDg0MmMtMi41MDQ3NCwyLjAwNjggLTE1LjE2ODA0LC0yLjQ3MzY3IC0xNS4xNjgwNCwtMi40NzM2N2MwLDAgLTguMDE3MDEsNy45NjIzNCAtMTEuNjM3OTMsNi45ODQwNGMtMy42MjMzLC0wLjk3NzY4IC0xLjE4MjkyLC0xMC40NDU0NSAtMS4xODI5MiwtMTAuNDQ1NDVjMCwwIC0xMy43NjMwNiwtMi42NTU3MSAtMTMuNDk1MTUsLTUuMjY4MDdjMC4yNjcwNCwtMi42MTQxIDE0LjQ0MDYyLC0zLjk4MjA1IDE0LjQ0MDYyLC0zLjk4MjA1YzAsMCAtMC40OTExNiwtOS42MDEzOCAzLjI5NDQxLC0xMC4yNDAxMWMzLjc5MTM4LC0wLjYzODI3IDEwLjExMjI4LDcuOTg0MSAxMC4xMTIyOCw3Ljk4NDFjMCwwIDEzLjQ1OSwtMy4yODA2IDE1LjUzMDI0LC0xLjA1OTY1YzIuMDc3ODMsMi4yMTc2MyAtOC4xOTExNyw4LjkxNjQxIC04LjE5MTE3LDguOTE2NDFjMCwwIDguODA5ODgsNy41NzU5NyA2LjI5NzY0LDkuNTg0NXoiIGZpbGw9IiMwMDAwMDAiIHN0cm9rZT0ibm9uZSIgc3Ryb2tlLXdpZHRoPSIwIi8+PHBhdGggZD0iTTI4OC4yMzgxMywxODQuMTU3NjJsLTEuNDM0OCwtNC45OTI3NWwxMS4xMjI1OSwtMTcuNDExOTFsMy4xMDQwNywyLjY2MzM3YzAsMCAtMTIuNzYyMDEsMTkuNzM1MTIgLTEyLjc5MTg1LDE5Ljc0MTI5eiIgZmlsbD0iI2ZmZmZmZiIgc3Ryb2tlPSJub25lIiBzdHJva2Utd2lkdGg9IjEiLz48cGF0aCBkPSJNMzE1LjczNzM4LDE4NS40NDg0MmMtMi41MDQ3NCwyLjAwNjggLTE1LjE2ODA0LC0yLjQ3MzY3IC0xNS4xNjgwNCwtMi40NzM2N2MwLDAgLTguMDE3MDEsNy45NjIzNCAtMTEuNjM3OTMsNi45ODQwNGMtMy42MjMzLC0wLjk3NzY4IC0xLjE4MjkyLC0xMC40NDU0NSAtMS4xODI5MiwtMTAuNDQ1NDVjMCwwIC0xMy43NjMwNiwtMi42NTU3MSAtMTMuNDk1MTUsLTUuMjY4MDdjMC4yNjcwNCwtMi42MTQxIDE0LjQ0MDYyLC0zLjk4MjA1IDE0LjQ0MDYyLC0zLjk4MjA1YzAsMCAtMC40OTExNiwtOS42MDEzOCAzLjI5NDQxLC0xMC4yNDAxMWMzLjc5MTM4LC0wLjYzODI3IDEwLjExMjI4LDcuOTg0MSAxMC4xMTIyOCw3Ljk4NDFjMCwwIDEzLjQ1OSwtMy4yODA2IDE1LjUzMDI0LC0xLjA1OTY1YzIuMDc3ODMsMi4yMTc2MyAtOC4xOTExNyw4LjkxNjQxIC04LjE5MTE3LDguOTE2NDFjMCwwIDguODA5ODgsNy41NzU5NyA2LjI5NzY0LDkuNTg0NXoiIGZpbGw9Im5vbmUiIHN0cm9rZS1vcGFjaXR5PSIwLjYyNzQ1IiBzdHJva2U9IiNmZmRjMDAiIHN0cm9rZS13aWR0aD0iMi41Ii8+PC9nPjxnPjxwYXRoIGQ9Ik0zNTQuNjEyODEsMTg1LjA0MDU4Yy0yLjUxODg1LDEuODY5ODYgLTE1LjAyMTksLTIuNDI4MDYgLTE1LjAyMTksLTIuNDI4MDZjMCwwIC04LjA4NjU3LDcuNDMxOTIgLTExLjY2NjQ4LDYuNDg3NzFjLTMuNTgyMjcsLTAuOTQzNjQgLTEuMDA5MTMsLTkuODI4NTcgLTEuMDA5MTMsLTkuODI4NTdjMCwwIC0xMy42MjM5NCwtMi41ODk3MyAtMTMuMzE2NTcsLTUuMDQ0YzAuMzA2NTQsLTIuNDU1OTEgMTQuNDAxODUsLTMuNjQ2MzkgMTQuNDAxODUsLTMuNjQ2MzljMCwwIC0wLjMzNTY3LC05LjAzMDM0IDMuNDMzMzMsLTkuNjA1MzFjMy43NzQ3OCwtMC41NzQ1MiA5LjkxNDU2LDcuNTc0NzMgOS45MTQ1Niw3LjU3NDczYzAsMCAxMy40MTYwMywtMi45OTM1MiAxNS40Mzc0OSwtMC44OTE0NmMyLjAyODA1LDIuMDk4OTggLTguMjc0NTksOC4zMjc3NCAtOC4yNzQ1OSw4LjMyNzc0YzAsMCA4LjYyNzc5LDcuMTgyMjMgNi4xMDE0Niw5LjA1MzY1eiIgZmlsbD0iIzAwMDAwMCIgc3Ryb2tlPSJub25lIiBzdHJva2Utd2lkdGg9IjAiLz48cGF0aCBkPSJNMzI3LjE4MDA0LDE4NC4xNTg3MWwtMS4zNDU2MiwtNC43MDM3NmwxMS4zMTk4NywtMTYuMjk1MjRsMy4wNDAwMiwyLjUyNTAxYzAsMCAtMTIuOTg0NTEsMTguNDY4NCAtMTMuMDE0MjYsMTguNDc0MDF6IiBmaWxsPSIjZmZmZmZmIiBzdHJva2U9Im5vbmUiIHN0cm9rZS13aWR0aD0iMSIvPjxwYXRoIGQ9Ik0zNTQuNjEyODEsMTg1LjA0MDU4Yy0yLjUxODg1LDEuODY5ODYgLTE1LjAyMTksLTIuNDI4MDYgLTE1LjAyMTksLTIuNDI4MDZjMCwwIC04LjA4NjU3LDcuNDMxOTIgLTExLjY2NjQ4LDYuNDg3NzFjLTMuNTgyMjcsLTAuOTQzNjQgLTEuMDA5MTMsLTkuODI4NTcgLTEuMDA5MTMsLTkuODI4NTdjMCwwIC0xMy42MjM5NCwtMi41ODk3MyAtMTMuMzE2NTcsLTUuMDQ0YzAuMzA2NTQsLTIuNDU1OTEgMTQuNDAxODUsLTMuNjQ2MzkgMTQuNDAxODUsLTMuNjQ2MzljMCwwIC0wLjMzNTY3LC05LjAzMDM0IDMuNDMzMzMsLTkuNjA1MzFjMy43NzQ3OCwtMC41NzQ1MiA5LjkxNDU2LDcuNTc0NzMgOS45MTQ1Niw3LjU3NDczYzAsMCAxMy40MTYwMywtMi45OTM1MiAxNS40Mzc0OSwtMC44OTE0NmMyLjAyODA1LDIuMDk4OTggLTguMjc0NTksOC4zMjc3NCAtOC4yNzQ1OSw4LjMyNzc0YzAsMCA4LjYyNzc5LDcuMTgyMjMgNi4xMDE0Niw5LjA1MzY1eiIgZmlsbD0ibm9uZSIgc3Ryb2tlLW9wYWNpdHk9IjAuNjI3NDUiIHN0cm9rZT0iI2ZmZGMwMCIgc3Ryb2tlLXdpZHRoPSIyLjUiLz48L2c+PHBhdGggZD0iTTI1OS43NSwyNDAuMjV2LTEyMC41aDEyMC41djEyMC41eiIgZmlsbD0ibm9uZSIgc3Ryb2tlPSJub25lIiBzdHJva2Utd2lkdGg9IjAiLz48L2c+PC9nPjwvc3ZnPg==';
 
 class dollyProExtension {
+  static extCount = 0;
+
   constructor(runtime) {
     this.runtime = runtime;
 
-    /** 克隆体ID映射表：ID → target */
-    this._IDtoTargets = {};
+    dollyProExtension.extCount += 1;
+    /** 递增计数的扩展id。预防一个奇妙的情况：扩展被重复加载） */
+    this.id = dollyProExtension.extCount;
 
-    /** 下个克隆体的预设的KV数据 */
-    this._clonePresetData = {};
-    /** 下个克隆体的预设属性('x'、'y'、'size'、'direction'等)的值*/
-    this._clonePresetProperties = {};
-    /** 克隆体预设的要加入的分组 */
-    this._clonePresetGroups = {};
-    /** 刚克隆的克隆体ID */
+    /** 克隆体ID映射表：ID → target
+     * @type {{[ID: string]: Target}}
+     */
+    this.IDtoTargets = {};
+
+    this.nextSpriteIDCount = 0;
+    this.nextCloneIDCount = 0;
+
+    /** 下个克隆体的预设的KV数据
+     * @type {{[key: string]: any}}
+     */
+    this.clonePresetData = {};
+
+    /** 下个克隆体的预设属性('x'、'y'、'size'、'direction'等)的值
+     * @type {{[prop: string]: any}
+     */
+    this.clonePresetProperties = {};
+
+    /** 克隆体预设的要加入的分组
+     * @type {{[group: string]: true}}}
+     */
+    this.clonePresetGroups = {};
+
+    /** 刚克隆的克隆体ID
+     * @type {string}
+     */
     this.justCreatedCloneID = '';
 
     /** 克隆体分组，每个组是一个克隆体ID列表
      * @type {{[groupName: string]: string[]}}
      */
-    this._groupsOfClones = {};
-    /** 存放 forEach 积木当前遍历的克隆体ID */
+    this.groupsOfClones = {};
+
+    /** 存放 forEach 积木当前遍历的克隆体ID
+     * @type {{[topBlockId: string]: string}}
+     */
     this.forEachIndex = {};
 
     /** 一个附加功能，将扩展中对原版xy方向的访问转移到对克隆体Key数据的访问
      * - 例如，x: 'x' 表示原来访问target.x，现在访问target.DollyPro.extraData['x']
      * - 默认都是 null，即访问原内容
+     * @type {{x: string|null, y: string|null, direction: string|null}}
      */
-    this._accessTransfer = { x: null, y: null, direction: null };
+    this.accessTransfer = { x: null, y: null, direction: null };
 
-    /** 是否隐藏不常用的多莉积木 */
+    /** 是否隐藏不常用的多莉积木
+     * @type {boolean}
+     */
     this.hideExtraBlocks = true;
 
+    if (!this.parseExtConfig()) {
+      runtime.on('PROJECT_LOADED', () => {
+        // 从作品注释读取扩展配置
+        this.parseExtConfig();
+      });
+    }
+
     /** Scratch 的 canvas 对象 */
-    this.canvas = null;
-    const elements = document.getElementsByTagName('canvas');
-    let cvs = null;
-    for (let i = 0; i < elements.length; i++) {
-      cvs = elements[i];
-      if (cvs.className === '') break;
-    }
-    if (cvs) {
-      this.canvas = cvs;
-    } else {
-      alert('dolly pro：获取canvas长宽失败！');
-    }
+    this.canvas = runtime.renderer.canvas;
+
+    const outerThis = this;
 
     // 劫持 runtime.getTargetById (根据Id找克隆体时，先从ID表查找)
-    this.runtime.__getTargetById = this.runtime.getTargetById;
-    this.runtime.getTargetById = function (ID) {
-      // 先从ID表查找
-      if (Object.prototype.hasOwnProperty.call(this._IDtoTargets, ID)) {
-        return this._IDtoTargets[ID];
-      }
-      // 没找到再用原版方法
-      return this.runtime.__getTargetById(ID);
-    }.bind(this);
+    this.tryHackedFunction(
+      this.runtime,
+      'getTargetById',
+      function getTargetById(origFun, ID) {
+        // 先从ID表查找
+        if (Object.prototype.hasOwnProperty.call(outerThis.IDtoTargets, ID)) {
+          return outerThis.IDtoTargets[ID];
+        }
+        // 没找到再用原版方法
+        return origFun.call(this, ID);
+      },
+    );
 
     // 劫持 runtime.removeExecutable
-    this.runtime.__removeExecutable = this.runtime.removeExecutable;
-    this.runtime.removeExecutable = function (target) {
-      // removeExecutable（删除角色/克隆体）之前，处理一下后事
-      this._processTargetBeforeDeletion(target);
-      this.runtime.__removeExecutable(target);
-    }.bind(this);
+    this.tryHackedFunction(
+      this.runtime,
+      'removeExecutable',
+      function removeExecutable(origFun, target) {
+        // removeExecutable（删除角色/克隆体）之前，处理一下后事
+        outerThis.processTargetBeforeDeletion(target);
+        origFun.call(this, target);
+      },
+    );
 
     // 劫持 runtime.disposeTarget
-    this.runtime.__disposeTarget = this.runtime.disposeTarget;
-    this.runtime.disposeTarget = function (target) {
-      // 避免循环删除
-      if (target.DollyPro) {
-        if (target.DollyPro.isDeleting) return;
-      }
-      this.__disposeTarget(target);
-    };
-    this._hackedDispose = function () {
+    this.tryHackedFunction(
+      this.runtime,
+      'disposeTarget',
+      function disposeTarget(origFun, target) {
+        // 避免循环删除
+        if (target.DollyPro) {
+          if (target.DollyPro.isDeleting) return;
+        }
+        origFun.call(this, target);
+      },
+    );
+
+    this.hackedDispose = function dispose(origFun) {
       // 避免循环删除
       if (this.DollyPro) {
         if (this.DollyPro.isDeleting) return;
       }
-      this.__dolly_orig_dispose();
+      origFun.call(this);
     };
-
     // 劫持 newClone.initDrawable
-    const _hackedInitDrawable = function (layerGroup) {
+    this.hackedInitDrawable = function initDrawable(origFun, layerGroup) {
       if (!this.isOriginal) {
         // 触发hat“当克隆体即将启动”
-        this.runtime.startHats('witCat.dollyPro_initTheClone', null, this);
+        outerThis.runtime.startHats(`${extensionId}_initTheClone`, null, this);
       }
-      this.__dolly_orig_initDrawable(layerGroup);
+      origFun.call(this, layerGroup);
     };
-    // 劫持 sprite.createClone
-    const _hackedCreateClone = function (optLayerGroup) {
-      const newClone = this.__dolly_orig_createClone(optLayerGroup);
-      // 劫持新产生的克隆体的initDrawable
-      if (!newClone.__dolly_orig_initDrawable) {
-        newClone.__dolly_orig_initDrawable = newClone.initDrawable;
-        newClone.initDrawable = _hackedInitDrawable;
-      }
-      return newClone;
-    };
-    // 作品加载后，给每个角色注入多莉，并劫持createClone
+
+    // 作品加载后，给每个角色注入多莉，并劫持RenderTarget方法
     setTimeout(() => {
-      this.runtime.targets.forEach((target) => {
-        if (!target.isStage) {
+      const { targets } = this.runtime;
+      if (targets) {
+        if (targets[0]) {
+          // 劫持RenderTarget.initDrawable
+          this.tryHackedRenderTarget(targets[0]);
+        }
+        targets.forEach((target) => {
           // 注入多莉
           this.injectDollyTarget(target);
-          if (target.sprite) {
-            // 劫持每个初始角色的createClone方法
-            if (!target.sprite.__dolly_orig_createClone) {
-              target.sprite.__dolly_orig_createClone =
-                target.sprite.createClone;
-              target.sprite.createClone = _hackedCreateClone;
-            }
-          }
-        }
-      });
+        });
+      }
     }, 1000);
 
     // 劫持 runtime.addTarget（用于创建新角色/克隆体时，注入多莉）
-    this.runtime.__addTarget = this.runtime.addTarget;
-    this.runtime.addTarget = function (target) {
-      // 注入多莉（角色本体、克隆体都要注入）
-      this.injectDollyTarget(target);
-      if (!target.isOriginal) {
-        // 如果是克隆体，进行一些预处理（如读取预设数据）
-        this.__processCloneBeforeCreation(target);
-        // 记录刚克隆的克隆体ID
-        this.justCreatedCloneID = this.getIDOfTarget(target);
-      } else {
-        // 如果是角色，劫持createClone
-        if (target.sprite) {
-          if (target.sprite.createClone !== _hackedCreateClone) {
-            target.sprite.__dolly_orig_createClone = target.sprite.createClone;
-            target.sprite.createClone = _hackedCreateClone;
-          }
+    this.tryHackedFunction(
+      runtime,
+      'addTarget',
+      function addTarget(origFun, target) {
+        // 注入多莉（角色本体、克隆体都要注入）
+        outerThis.injectDollyTarget(target);
+        if (!target.isOriginal) {
+          // 如果是克隆体，进行一些预处理（如读取预设数据）
+          outerThis.processCloneBeforeCreation(target);
+          // 记录刚克隆的克隆体ID
+          outerThis.justCreatedCloneID = outerThis.getIDOfTarget(target);
         }
-      }
-      this.runtime.__addTarget(target);
-    }.bind(this);
+        origFun.call(this, target);
+      },
+    );
 
     this.fm = this.runtime.getFormatMessage({
       'zh-cn': {
         'witCat.dollyPro.name': '多莉Pro',
         'witCat.dollyPro.urlButton': '📖 扩展教程',
-        'witCat.dollyPro.url': 'https://learn.ccw.site/article/',
+        'witCat.dollyPro.url':
+          'https://learn.ccw.site/article/9b9b43cd-75c3-4271-998c-b7c250fc81b9',
         'witCat.dollyPro.tag.utils': '🔧 常用工具',
         'witCat.dollyPro.tag.event': '🔔 事件触发',
         'witCat.dollyPro.tag.cloneAndDelete': '🪄 克隆与删除',
@@ -190,6 +191,16 @@ class dollyProExtension {
         'witCat.dollyPro.tag.motion': '🚶 运动相关',
         'witCat.dollyPro.tag.sensing': '🔍 侦测相关',
         'witCat.dollyPro.tag.test': '🚧 实验积木',
+
+        'witCat.dollyPro.warn.newIDIsOldID':
+          '多莉pro：修改的角色ID已经是 "%s"!',
+        'witCat.dollyPro.warn.repetitveID':
+          '多莉pro：已存在ID为 "%s"的克隆体或角色，请不要设置相同 ID！',
+        'witCat.dollyPro.error.repetitiveID':
+          '多莉pro: 已经存在ID为 "%s" 的克隆体，克隆时请勿使用相同ID！',
+        'witCat.dollyPro.config.tip':
+          '该注释用于保存多莉Pro扩展信息\n你可以拖动/缩放这个注释。不建议直接编辑注释文字。可以删除这个注释来清除扩展配置信息',
+
         'witCat.dollyPro.button.showBlock': '显示不常用的多莉积木',
         'witCat.dollyPro.button.hideBlock': '隐藏不常用的多莉积木',
         'witCat.dollyPro.confirm.showBlock?':
@@ -342,6 +353,16 @@ class dollyProExtension {
         'witCat.dollyPro.tag.test': '🚧 Experimental Blocks',
         'witCat.dollyPro.button.showBlock': 'show other blocks',
         'witCat.dollyPro.button.hideBlock': 'hide other blocks',
+
+        'witCat.dollyPro.warn.newIDIsOldID':
+          'Dolly pro: The modified sprite ID is already "%s"!',
+        'witCat.dollyPro.warn.repetitveID':
+          'Dolly pro: There is already a clone or sprite with ID "%s", please do not set the same ID!',
+        'witCat.dollyPro.error.repetitiveID':
+          'Dolly pro: There is already a clone with the ID "%s". Please do not use the same ID when cloning!',
+        'witCat.dollyPro.config.tip':
+          'Configuration for Arkos Extension(Inspired by TurboWarp)\nYou can move, resize, and minimize this comment, but better not edit it by hand. This comment can be deleted to remove the stored settings.',
+
         'witCat.dollyPro.confirm.showBlock?':
           'To avoid clutter, some infrequently used blocks are hidden.\nDo you want to show hidden blocks?',
         'witCat.dollyPro.block.addOrRemoveIDFromGroup':
@@ -377,7 +398,7 @@ class dollyProExtension {
         'witCat.dollyPro.block.getClonePropertyWithID':
           '[PROPERTY] of clone[ID]',
         'witCat.dollyPro.block.getCloneTargetPropertyWithSpriteName':
-          '[PROPERTY] of [TARGET]\'s clones',
+          'clone [PROPERTY] of [TARGET]',
         'witCat.dollyPro.block.getGroupInfo':
           '[PROPERTY] of clones in group [GROUP]',
         'witCat.dollyPro.block.getJustCreatedCloneID':
@@ -448,10 +469,10 @@ class dollyProExtension {
         'witCat.dollyPro.defaultValue.player': 'player',
         'witCat.dollyPro.defaultValue.presetJSON':
           '\'{"name":"common soldier ","HP":100,"team":"red"}\'',
-        'witCat.dollyPro.menu.cloneProperty.IDList': 'list of IDs',
+        'witCat.dollyPro.menu.cloneProperty.IDList': 'lists',
         'witCat.dollyPro.menu.cloneProperty.allSprite': 'all sprites',
         'witCat.dollyPro.menu.cloneProperty.anySprite': 'any sprite',
-        'witCat.dollyPro.menu.cloneProperty.count': 'number',
+        'witCat.dollyPro.menu.cloneProperty.count': 'count',
         'witCat.dollyPro.menu.cloneProperty.json': 'JSON',
         'witCat.dollyPro.menu.cloneProperty.myself': 'myself',
         'witCat.dollyPro.menu.spriteProperty._size': 'size',
@@ -486,21 +507,21 @@ class dollyProExtension {
   }
 
   formatMessage(id) {
-    id = `witCat.dollyPro.${id}`;
+    const newid = `witCat.dollyPro.${id}`;
     return this.fm({
-      id,
-      default: id,
-      description: id,
+      newid,
+      default: newid,
+      description: newid,
     });
   }
 
   getHats() {
     return {
-      'witCat.dollyPro_dispatchWhenCloned': {},
-      'witCat.dollyPro_dispatchWhenCloneDeleted': {},
-      'witCat.dollyPro_initTheClone': {},
-      'witCat.dollyPro_beforeDeletionOfTheClone': {},
-      'witCat.dollyPro_receiveMyBroadcast': {},
+      [`${extensionId}_dispatchWhenCloned`]: {},
+      [`${extensionId}_dispatchWhenCloneDeleted`]: {},
+      [`${extensionId}_initTheClone`]: {},
+      [`${extensionId}_beforeDeletionOfTheClone`]: {},
+      [`${extensionId}_receiveMyBroadcast`]: {},
     };
   }
 
@@ -511,27 +532,18 @@ class dollyProExtension {
       menuIconURI: icon,
       blockIconURI: icon,
       color1: '#FA8D0D',
+      docsURI: this.formatMessage('url'),
       blocks: [
-        // 扩展文档按钮
-        {
-          blockType: 'button',
-          text: this.formatMessage('urlButton'),
-          onClick: () => {
-            const a = document.createElement('a');
-            a.href = this.formatMessage('url');
-            a.rel = 'noopener noreferrer';
-            a.target = '_blank';
-            a.click();
-          },
-        },
         // 按钮：显示不常用积木
         {
           blockType: 'button',
           hideFromPalette: !this.hideExtraBlocks,
           text: this.formatMessage('button.showBlock'),
           onClick: () => {
+            // eslint-disable-next-line no-restricted-globals
             if (confirm(this.formatMessage('confirm.showBlock?'))) {
               this.hideExtraBlocks = false;
+              this.storeExtConfig();
               this.runtime.emit('TOOLBOX_EXTENSIONS_NEED_UPDATE');
             }
           },
@@ -543,10 +555,11 @@ class dollyProExtension {
           hideFromPalette: this.hideExtraBlocks,
           onClick: () => {
             this.hideExtraBlocks = true;
+            this.storeExtConfig();
             this.runtime.emit('TOOLBOX_EXTENSIONS_NEED_UPDATE');
           },
         },
-        '---' + this.formatMessage('tag.utils'),
+        `---${this.formatMessage('tag.utils')}`,
         // 判断我是克隆体/本体吗
         {
           opcode: 'isCloneOrIsOriginal',
@@ -560,12 +573,13 @@ class dollyProExtension {
             },
           },
         },
-        // 获取角色的克隆体数量/ID表
+        // （旧积木：参数无法塞入圆形积木）获取角色的克隆体数量/ID表
         {
           opcode: 'getCloneTargetPropertyWithSpriteName',
           blockType: BlockType.REPORTER,
+          hideFromPalette: true,
           text: this.formatMessage(
-            'block.getCloneTargetPropertyWithSpriteName'
+            'block.getCloneTargetPropertyWithSpriteName',
           ),
           arguments: {
             TARGET: {
@@ -578,13 +592,32 @@ class dollyProExtension {
             },
           },
         },
-        // 获取角色ID等信息
+        // （新积木：参数可以塞入圆形积木）获取角色的克隆体数量/ID表
+        {
+          opcode: 'getCloneTargetPropertyWithSpriteName2',
+          blockType: BlockType.REPORTER,
+          text: this.formatMessage(
+            'block.getCloneTargetPropertyWithSpriteName',
+          ),
+          arguments: {
+            TARGET: {
+              type: ArgumentType.STRING,
+              menu: 'NEW_SPRITE_MENU_WITH_ALL',
+            },
+            PROPERTY: {
+              type: ArgumentType.STRING,
+              menu: 'CLONE_PROPERTY',
+            },
+          },
+        },
+        // （旧积木：参数无法塞入圆形积木）获取角色ID等信息
         {
           opcode: 'getOriginalTargetPropertyWithSpriteName',
           blockType: BlockType.REPORTER,
           disableMonitor: true,
+          hideFromPalette: true,
           text: this.formatMessage(
-            'block.getOriginalTargetPropertyWithSpriteName'
+            'block.getOriginalTargetPropertyWithSpriteName',
           ),
           arguments: {
             TARGET: {
@@ -597,7 +630,26 @@ class dollyProExtension {
             },
           },
         },
-        '---' + this.formatMessage('tag.event'),
+        // （新积木：参数可以塞入圆形积木）获取角色ID等信息
+        {
+          opcode: 'getOriginalTargetPropertyWithSpriteName2',
+          blockType: BlockType.REPORTER,
+          disableMonitor: true,
+          text: this.formatMessage(
+            'block.getOriginalTargetPropertyWithSpriteName',
+          ),
+          arguments: {
+            TARGET: {
+              type: ArgumentType.STRING,
+              menu: 'NEW_SPRITE_MENU',
+            },
+            PROPERTY: {
+              type: ArgumentType.STRING,
+              menu: 'SPRITE_PROPERTY',
+            },
+          },
+        },
+        `---${this.formatMessage('tag.event')}`,
         // 克隆体启动前执行的动作
         {
           blockType: BlockType.EVENT,
@@ -694,7 +746,7 @@ class dollyProExtension {
             },
           },
         },
-        '---' + this.formatMessage('tag.cloneAndDelete'),
+        `---${this.formatMessage('tag.cloneAndDelete')}`,
         // 预设克隆体 x/y/方向...
         {
           opcode: 'presetPropertyForTheNextClone',
@@ -733,7 +785,7 @@ class dollyProExtension {
           blockType: BlockType.COMMAND,
           hideFromPalette: this.hideExtraBlocks,
           text: this.formatMessage(
-            'block.presetDataforTheNextCloneInJSONFormat'
+            'block.presetDataforTheNextCloneInJSONFormat',
           ),
           arguments: {
             DATA_JSON: {
@@ -746,7 +798,7 @@ class dollyProExtension {
         {
           opcode: 'presetGroupForTheNextClone',
           blockType: BlockType.COMMAND,
-          hideFromPalette: this.hideExtraBlocks,
+          // hideFromPalette: this.hideExtraBlocks,
           text: this.formatMessage('block.presetGroupForTheNextClone'),
           arguments: {
             GROUP: {
@@ -801,7 +853,7 @@ class dollyProExtension {
             },
           },
         },
-        '---' + this.formatMessage('tag.data'),
+        `---${this.formatMessage('tag.data')}`,
         // 读取我的信息：ID/x坐标/y坐标...
         {
           opcode: 'getMyProperty',
@@ -930,7 +982,7 @@ class dollyProExtension {
             },
           },
         },
-        '---' + this.formatMessage('tag.group'),
+        `---${this.formatMessage('tag.group')}`,
         // 将我加入/移出分组
         {
           opcode: 'addOrRemoveMyselfFromGroup',
@@ -1063,7 +1115,7 @@ class dollyProExtension {
           text: this.formatMessage('block.cloneIDOfForEach'),
           disableMonitor: true,
         },
-        '---' + this.formatMessage('tag.sensing'),
+        `---${this.formatMessage('tag.sensing')}`,
         // 获取分组..中最近克隆体ID
         {
           opcode: 'getNearestClone',
@@ -1215,7 +1267,7 @@ class dollyProExtension {
             },
           },
         },
-        '---' + this.formatMessage('tag.motion'),
+        `---${this.formatMessage('tag.motion')}`,
         // 计算我到克隆体..的距离/方向/角度差/..
         {
           opcode: 'calcDistanceToClone',
@@ -1293,7 +1345,7 @@ class dollyProExtension {
         },
         ...(this.hideExtraBlocks
           ? []
-          : ['---' + this.formatMessage('tag.test')]),
+          : [`---${this.formatMessage('tag.test')}`]),
         // 修改我的ID
         {
           opcode: 'setMyID',
@@ -1313,7 +1365,7 @@ class dollyProExtension {
           blockType: BlockType.COMMAND,
           hideFromPalette: this.hideExtraBlocks,
           text: this.formatMessage(
-            'block.transferAccessToTargetXYToDollyDataKey'
+            'block.transferAccessToTargetXYToDollyDataKey',
           ),
           arguments: {
             X_NAME: {
@@ -1330,7 +1382,7 @@ class dollyProExtension {
             },
           },
         },
-        //取消x/y/方向的访问转移
+        // 取消x/y/方向的访问转移
         {
           opcode: 'cancelAccessTransfer',
           hideFromPalette: this.hideExtraBlocks,
@@ -1399,13 +1451,13 @@ class dollyProExtension {
             },
             {
               text: this.formatMessage(
-                'menu.calcBetweenClones.angleDifference'
+                'menu.calcBetweenClones.angleDifference',
               ),
               value: 'angle',
             },
             {
               text: this.formatMessage(
-                'menu.calcBetweenClones.absAngleDifference'
+                'menu.calcBetweenClones.absAngleDifference',
               ),
               value: 'absAngle',
             },
@@ -1502,23 +1554,38 @@ class dollyProExtension {
         },
 
         SPRITE_MENU: {
-          items: '__spriteMenuWithEmptyChecking',
+          acceptReporters: false,
+          items: 'spriteMenuWithEmptyChecking',
         },
         SPRITE_MENU_WITH_ALL: {
-          items: '__spriteMenuWithAll',
+          acceptReporters: false,
+          items: 'spriteMenuWithAll',
         },
+        // 这两个菜单换成可以接受reporters
+        NEW_SPRITE_MENU: {
+          acceptReporters: true,
+          items: 'spriteMenuWithEmptyChecking',
+        },
+        NEW_SPRITE_MENU_WITH_ALL: {
+          acceptReporters: true,
+          items: 'spriteMenuWithAll',
+        },
+
         SPRITE_MENU_WITH_ANY: {
-          items: '__spriteMenuWithAny',
+          acceptReporters: false,
+          items: 'spriteMenuWithAny',
         },
         SPRITE_MENU_WITH_MYSELF: {
           acceptReporters: true,
-          items: '__spriteMenuWithMyself',
+          items: 'spriteMenuWithMyself',
         },
 
         LIST_MENU: {
-          items: '__listMenu',
+          acceptReporters: false,
+          items: 'listMenu',
         },
         PRESET_PROPERTY: {
+          acceptReporters: false,
           items: [
             {
               text: this.formatMessage('menu.spriteProperty._x'),
@@ -1542,7 +1609,7 @@ class dollyProExtension {
             },
             {
               text: this.formatMessage(
-                'menu.spriteProperty.currentCostumeName'
+                'menu.spriteProperty.currentCostumeName',
               ),
               value: 'currentCostumeName',
             },
@@ -1612,7 +1679,7 @@ class dollyProExtension {
             },
             {
               text: this.formatMessage(
-                'menu.spriteProperty.currentCostumeName'
+                'menu.spriteProperty.currentCostumeName',
               ),
               value: 'currentCostumeName',
             },
@@ -1670,31 +1737,125 @@ class dollyProExtension {
     };
   }
 
+  // ******************** ↓扩展配置读取&保存（参考了 tw 的通过注释来保存配置） ********************
+
+  /** 查找扩展配置的注释（在舞台区） */
+  findExtConfigComment() {
+    const stage = this.runtime.getTargetForStage();
+    if (!stage || !stage.comments) return undefined;
+    return stage.comments[EXT_CONFIG_COMMENT_ID];
+  }
+
+  /**
+   * 从注释获取所有扩展配置
+   * @returns  {{[extensionId: string]:object}}  {扩展1:...扩展2:...}
+   */
+  getAllExtConfig() {
+    const comment = this.findExtConfigComment();
+    if (!comment) return undefined;
+    const lines = comment.text.split('\n');
+    if (lines.length === 0) {
+      console.warn(
+        `${extensionId}: Extension config comment does not contain valid line.`,
+      );
+      return undefined;
+    }
+    // 配置信息存在最后一行
+    const jsonText = lines[lines.length - 1];
+    try {
+      const parsed = JSON.parse(jsonText);
+      if (!parsed || typeof parsed !== 'object') {
+        throw new Error('Invalid object');
+      }
+      return parsed;
+    } catch (e) {
+      console.warn(`${extensionId}: Config comment has invalid JSON`, e);
+      return undefined;
+    }
+  }
+
+  /** 从舞台注释应用扩展配置
+   * @returns {boolean} 是否成功
+   */
+  parseExtConfig() {
+    let config = this.getAllExtConfig();
+    if (!config) return false;
+    config = config[extensionId];
+    if (!config) return false;
+    if ('hideExtraBlocks' in config) {
+      this.hideExtraBlocks = Cast.toBoolean(config.hideExtraBlocks);
+      this.runtime.emit('TOOLBOX_EXTENSIONS_NEED_UPDATE');
+    }
+    return true;
+  }
+
+  /**
+   * 生成当前扩展的配置
+   * @returns {object} 配置信息
+   */
+  generateExtConfig() {
+    const options = {};
+    options.hideExtraBlocks = this.hideExtraBlocks;
+    return options;
+  }
+
+  storeExtConfig() {
+    // 设置配置
+    let config = this.getAllExtConfig();
+    if (!config) config = {};
+    config[extensionId] = this.generateExtConfig();
+
+    const existingComment = this.findExtConfigComment();
+    if (existingComment) {
+      const lines = existingComment.text.split('\n');
+      if (lines.length === 0) {
+        lines.push('');
+      }
+      // 配置信息存在最后一行
+      lines[lines.length - 1] = JSON.stringify(config);
+      existingComment.text = lines.join('\n');
+    } else {
+      const target = this.runtime.getTargetForStage();
+      // TODO: smarter position logic
+      const text = `${this.formatMessage('config.tip')}\n${JSON.stringify(
+        config,
+      )}`;
+      target.createComment(
+        EXT_CONFIG_COMMENT_ID,
+        null,
+        text,
+        1,
+        1,
+        400,
+        200,
+        false,
+      );
+    }
+    this.runtime.emitProjectChanged();
+  }
+
   // **************************** 动态菜单 ****************************
   /**
    * 获取角色菜单
    * @returns {[{text: "角色名", value: "角色名"}]};
    */
-  __getSpriteMenu() {
-    const targets = this.runtime.targets;
+  getSpriteMenu() {
+    const { targets } = this.runtime;
 
     return targets
-      .filter((target) => {
-        return !target.isStage && target.isOriginal;
-      })
-      .map((target) => {
-        return {
-          text: target.sprite.name,
-          value: target.sprite.name,
-        };
-      });
+      .filter((target) => !target.isStage && target.isOriginal)
+      .map((target) => ({
+        text: target.sprite.name,
+        value: target.sprite.name,
+      }));
   }
+
   /**
    * 角色菜单并检查是否为空
    * @returns {[{text: "角色名", value: "角色名"}]};
    */
-  __spriteMenuWithEmptyChecking() {
-    let menu = this.__getSpriteMenu();
+  spriteMenuWithEmptyChecking() {
+    const menu = this.getSpriteMenu();
     if (menu.length === 0) {
       menu.push({
         text: '-',
@@ -1703,45 +1864,48 @@ class dollyProExtension {
     }
     return menu;
   }
+
   /**
    * 角色菜单（但是多一项“所有”）
    * @returns {text: "角色名", value: "角色名"}[];
    */
-  __spriteMenuWithAll() {
-    let menu = this.__getSpriteMenu();
+  spriteMenuWithAll() {
+    const menu = this.getSpriteMenu();
     menu.unshift({
       text: this.formatMessage('menu.cloneProperty.allSprite'),
       value: '_all_',
     });
     return menu;
   }
+
   /**
    * 角色菜单（但是多一项“任意角色”）
    * @returns {text: "角色名", value: "角色名"}[];
    */
-  __spriteMenuWithAny() {
-    let menu = this.__getSpriteMenu();
+  spriteMenuWithAny() {
+    const menu = this.getSpriteMenu();
     menu.unshift({
       text: this.formatMessage('menu.cloneProperty.anySprite'),
       value: '_all_',
     });
     return menu;
   }
+
   /**
    * 角色菜单（但是多一项“自己”）
    * @returns {text: "角色名", value: "角色名"}[];
    */
-  __spriteMenuWithMyself() {
-    let menu = this.__spriteMenuWithEmptyChecking();
-    //当前角色名称
+  spriteMenuWithMyself() {
+    const menu = this.spriteMenuWithEmptyChecking();
+    // 当前角色名称
     if (!this.runtime._editingTarget) return menu;
     const editingTargetName = this.runtime._editingTarget.sprite.name;
-    //从列表删除自己
-    let index = menu.findIndex((item) => item.value === editingTargetName);
+    // 从列表删除自己
+    const index = menu.findIndex((item) => item.value === editingTargetName);
     if (index !== -1) {
       menu.splice(index, 1);
     }
-    //列表第一项插入“自己”
+    // 列表第一项插入“自己”
     if (this.runtime._editingTarget.isStage) return menu;
     menu.unshift({
       text: this.formatMessage('menu.cloneProperty.myself'),
@@ -1754,9 +1918,9 @@ class dollyProExtension {
    * Scratch列表的菜单
    * @returns {text: "列表名", value: "列表id"}[];
    */
-  __listMenu() {
+  listMenu() {
     const menus = [];
-    let variables = this.runtime._stageTarget.variables;
+    let { variables } = this.runtime._stageTarget;
     Object.keys(variables).forEach((variable) => {
       if (variables[variable].type === 'list') {
         menus.push({
@@ -1771,8 +1935,8 @@ class dollyProExtension {
       variables = 'error';
     }
     if (
-      variables !== 'error' &&
-      this.runtime._editingTarget !== this.runtime._stageTarget
+      variables !== 'error'
+      && this.runtime._editingTarget !== this.runtime._stageTarget
     ) {
       Object.keys(variables).forEach((variable) => {
         if (variables[variable].type) {
@@ -1795,22 +1959,84 @@ class dollyProExtension {
   // ************************ ↓一些工具函数 ************************
 
   /**
+   * （如果之前没有劫持）劫持obj对象的方法
+   * @param {*} obj
+   * @param {string} funName 方法名
+   * @param {Function} newFun 注入的方法
+   */
+  tryHackedFunction(obj, funName, newFun) {
+    if (!obj.dollyProOrigFun) {
+      // eslint-disable-next-line no-param-reassign
+      obj.dollyProOrigFun = {}; // 记录原版函数
+    }
+    if (!obj.dollyProOrigFun[funName]) {
+      // 记录原函数
+      obj.dollyProOrigFun[funName] = obj[funName];
+    }
+    const origFun = obj.dollyProOrigFun[funName];
+    if (origFun.id !== this.id) {
+      origFun.id = this.id;
+      // 替换原始方法为新方法
+      // eslint-disable-next-line no-param-reassign
+      obj[funName] = function (...args) {
+        return newFun.call(this, origFun, ...args);
+      };
+    }
+  }
+
+  /**
+   * 根据得到的renderTarget实例，劫持其原型RenderTarget的方法
+   * @param {Target} target
+   */
+  tryHackedRenderTarget(target) {
+    const proto = Object.getPrototypeOf(target);
+    this.tryHackedFunction(proto, 'initDrawable', this.hackedInitDrawable);
+    this.tryHackedFunction(proto, 'dispose', this.hackedDispose);
+  }
+
+  /** 生成targetID
+   * @param {Target} target 要生成ID的target
+   * @param {string} specID （选填）指定ID
+   * @returns {string} 生成的ID，形如sprite_name或clone_#
+   */
+  generateTargetID(target, specID) {
+    let ID;
+    // 指定了ID，使用指定ID
+    if (specID !== undefined) {
+      ID = specID;
+    } else if (target.isStage) {
+      ID = 'stage';
+    } else if (target.isOriginal) {
+      this.nextSpriteIDCount += 1;
+      ID = `sprite_${this.nextSpriteIDCount}`;
+    } else {
+      this.nextCloneIDCount += 1;
+      ID = `clone_${this.nextCloneIDCount}`;
+    }
+    // 已经有相同ID，使用原ID
+    if (Object.prototype.hasOwnProperty.call(this.IDtoTargets, ID)) {
+      ID = target.id;
+    }
+    return ID;
+  }
+
+  /**
    * 向 target（克隆体/角色）注入 Dolly 数据（如果还没注入）
    * @param {ITarget} target 要注入的target
    * @param {string} ID 自定义ID（默认为原版的target.id)
    */
-  injectDollyTarget(target, ID = target.id) {
-    //已注入，退出
+  injectDollyTarget(target, ID) {
+    // 已注入，退出
     if (target.DollyPro) return;
 
     // 狠狠注入多莉数据（doge）
     target.DollyPro = {
-      ID: ID, // 克隆体多莉ID (不指定则默认为原版target.id)
+      ID: this.generateTargetID(target, ID), // 克隆体多莉ID (不指定则默认为原版target.id)
       extraData: {}, // 克隆体的 KV 数据
       isInGroup: {}, // 记录是否在某个组，例如 isInGroup["敌人"] == true
     };
-    //加入ID映射表
-    this._IDtoTargets[target.DollyPro.ID] = target;
+    // 加入ID映射表
+    this.IDtoTargets[target.DollyPro.ID] = target;
   }
 
   /**
@@ -1820,15 +2046,16 @@ class dollyProExtension {
    */
   getTargetByID(ID) {
     // 先从ID映射表找
-    if (Object.prototype.hasOwnProperty.call(this._IDtoTargets, ID)) {
-      return this._IDtoTargets[ID];
+    if (Object.prototype.hasOwnProperty.call(this.IDtoTargets, ID)) {
+      return this.IDtoTargets[ID];
     }
     //  ID表没找到，再使用原版方法找
-    let target = this.runtime.getTargetById(ID);
+    const target = this.runtime.getTargetById(ID);
     if (target) {
       this.injectDollyTarget(target);
       return target;
     }
+    return undefined;
   }
 
   /** 读取target的ID */
@@ -1844,99 +2071,102 @@ class dollyProExtension {
   }
 
   /** 克隆体克隆后，进行一些处理（包括读取预设数据、触发hat） */
-  __processCloneBeforeCreation(target) {
+  processCloneBeforeCreation(target) {
     // 读取预设KV数据
-    target.DollyPro.extraData = Object.assign({}, this._clonePresetData);
+    target.DollyPro.extraData = { ...this.clonePresetData };
     // 加入预设分组
     const ID = this.getIDOfTarget(target);
-    for (const group in this._clonePresetGroups) {
-      if (this._clonePresetGroups[group]) {
+
+    Object.keys(this.clonePresetGroups).forEach((group) => {
+      if (this.clonePresetGroups[group]) {
         target.DollyPro.isInGroup[group] = true;
         const list = this.getOrCreateGroupByName(group);
         list.push(ID);
       }
-    }
-    //读取预设属性（x、y、direction等）
-    const presetProps = this._clonePresetProperties;
-    for (const prop in presetProps) {
-      this.__opPropertyOfTarget(target, prop, 'set', presetProps[prop]);
-    }
+    });
 
-    //读取结束后，清空预设数据
-    this._clonePresetData = {};
-    this._clonePresetProperties = {};
-    this._clonePresetGroups = {};
+    // 读取预设属性（x、y、direction等）
+    Object.keys(this.clonePresetProperties).forEach((prop) => {
+      this.opPropertyOfTarget(
+        target,
+        prop,
+        'set',
+        this.clonePresetProperties[prop],
+      );
+    });
+
+    // 读取结束后，清空预设数据
+    this.clonePresetData = {};
+    this.clonePresetProperties = {};
+    this.clonePresetGroups = {};
 
     // 广播克隆体产生的hat
-    this.runtime.startHatsWithParams('witCat.dollyPro_dispatchWhenCloned', {
+    this.runtime.startHatsWithParams(`${extensionId}_dispatchWhenCloned`, {
       parameters: { ID },
       fields: { TARGET: target.sprite.name },
     });
-    this.runtime.startHatsWithParams('witCat.dollyPro_dispatchWhenCloned', {
+    this.runtime.startHatsWithParams(`${extensionId}_dispatchWhenCloned`, {
       parameters: { ID },
       fields: { TARGET: '_all_' },
     });
-    // 劫持target.dispose
-    if (!target.__dolly_orig_dispose) {
-      target.__dolly_orig_dispose = target.dispose;
-      target.dispose = this._hackedDispose;
-    }
   }
 
   /**
    * 在移除 target(角色/克隆体)前，处理后事
    * @param {ITarget} target 即将被移除的target
    */
-  _processTargetBeforeDeletion(target) {
+  processTargetBeforeDeletion(target) {
     let ID;
     if (!target.DollyPro) {
       // 如果target没接入多莉系统
       ID = target.id;
     } else {
-      //如果 target 接入多莉系统
+      // 如果 target 接入多莉系统
       ID = target.DollyPro.ID;
       // 如果target是克隆体
       if (!target.isOriginal) {
         // 广播“有角色的克隆体被删除”的hat积木
         this.runtime.startHatsWithParams(
-          'witCat.dollyPro_dispatchWhenCloneDeleted',
+          `${extensionId}_dispatchWhenCloneDeleted`,
           {
             parameters: { ID },
             fields: { TARGET: target.sprite.name },
-          }
+          },
         );
         this.runtime.startHatsWithParams(
-          'witCat.dollyPro_dispatchWhenCloneDeleted',
+          `${extensionId}_dispatchWhenCloneDeleted`,
           {
             parameters: { ID },
             fields: { TARGET: '_all_' },
-          }
+          },
         );
         // 标记克隆体为正在删除
         target.DollyPro.isDeleting = true;
         // 触发“本克隆体即将删除”的hat积木
         const threads = this.runtime.startHats(
-          'witCat.dollyPro_beforeDeletionOfTheClone',
+          `${extensionId}_beforeDeletionOfTheClone`,
           null,
-          target
+          target,
         );
         // 立即执行该 hat（克隆体执行完该hat后，就被立即删除）
-        threads.forEach((thread) => {
-          this.runtime.sequencer.stepThread(thread);
-        });
+        if (threads) {
+          threads.forEach((thread) => {
+            this.runtime.sequencer.stepThread(thread);
+          });
+        }
       }
 
       // 从克隆体分组中移除 target
-      for (const group in target.DollyPro.isInGroup) {
+      Object.keys(target.DollyPro.isInGroup).forEach((group) => {
         const list = this.getGroupByName(group);
-        if (!list) continue;
+        if (!list) return;
         const idx = list.indexOf(ID);
-        if (idx === -1) continue;
+        if (idx === -1) return;
         list.splice(idx, 1);
-      }
+      });
     }
     // 从ID映射表移除target
-    delete this._IDtoTargets[ID];
+    delete this.IDtoTargets[ID];
   }
 
   /**
@@ -1945,56 +2175,62 @@ class dollyProExtension {
    * @param  {...string} props 要读取的内容，例如'x','y','direction'
    * @returns {[number]} 读取结果，如[123,123]
    */
-  _getTargetXYDir(target, ...props) {
-    let res = [];
-    for (const prop of props) {
-      const key = this._accessTransfer[prop];
-      if (key && !target.isPoint) res.push(this.__getDataOfTarget(target, key));
+  getTargetXYDir(target, ...props) {
+    const res = [];
+    props.forEach((prop) => {
+      const key = this.accessTransfer[prop];
+      if (key && !target.isPoint) res.push(this.getDataOfTarget(target, key));
       else {
         res.push(target[prop]);
       }
-    }
+    });
     if (res.length < 2) return res[0];
     return res;
   }
-  /** 周期裁剪（例如11裁剪到1~10,返回1）*/
-  __wrapClamp(n, min, max) {
+
+  /** 周期裁剪（例如11裁剪到1~10,返回1） */
+  wrapClamp(n, min, max) {
     const range = max - min + 1;
     return n - Math.floor((n - min) / range) * range;
   }
+
   /** 普通裁剪 */
-  __clamp(n, min, max) {
+  clamp(n, min, max) {
     return Math.min(Math.max(n, min), max);
   }
+
   /**
    * 设置target的x,y,direction
    * @param {ITarget} target 要设置的对象
    * @param  {object} props 要设置内容，如{x:['set',123], y:['change',123], direction:['set',123]}
    */
-  _setTargetXYDir(target, props) {
-    let newX, newY;
-    for (const prop in props) {
+  setTargetXYDir(target, props) {
+    let newX;
+    let newY;
+    Object.keys(props).forEach((prop) => {
       const op = props[prop][0];
       const value = props[prop][1];
-      const key = this._accessTransfer[prop];
+      const key = this.accessTransfer[prop];
       if (key) {
-        this.__setOrChangeDataOfTarget(target, key, op, value);
+        this.setOrChangeDataOfTarget(target, key, op, value);
         if (prop === 'direction') {
-          const dir = this.__wrapClamp(
-            this.__getDataOfTarget(target, key),
+          const dir = this.wrapClamp(
+            this.getDataOfTarget(target, key),
             -179,
-            180
+            180,
           );
-          this.__setOrChangeDataOfTarget(target, key, 'set', dir);
+          this.setOrChangeDataOfTarget(target, key, 'set', dir);
         }
       } else {
         switch (prop) {
           case 'x':
             if (op === 'set') newX = value;
+            // eslint-disable-next-line no-underscore-dangle
             else newX = target._x + value;
             break;
           case 'y':
             if (op === 'set') newY = value;
+            // eslint-disable-next-line no-underscore-dangle
             else newY = target._y + value;
             break;
           case 'direction':
@@ -2005,7 +2241,7 @@ class dollyProExtension {
             break;
         }
       }
-    }
+    });
     if (newX !== undefined || newY !== undefined) {
       target.setXY(newX ?? target.x, newY ?? target.y);
     }
@@ -2017,7 +2253,7 @@ class dollyProExtension {
    * @return {[[ID: string]]} 克隆体分组ID表
    */
   getGroupByName(groupName) {
-    return this._groupsOfClones[groupName];
+    return this.groupsOfClones[groupName];
   }
 
   /**
@@ -2026,12 +2262,10 @@ class dollyProExtension {
    * @return {[[ID: string]]} 克隆体分组ID表
    */
   getOrCreateGroupByName(groupName) {
-    if (
-      !Object.prototype.hasOwnProperty.call(this._groupsOfClones, groupName)
-    ) {
-      this._groupsOfClones[groupName] = [];
+    if (!Object.prototype.hasOwnProperty.call(this.groupsOfClones, groupName)) {
+      this.groupsOfClones[groupName] = [];
     }
-    return this._groupsOfClones[groupName];
+    return this.groupsOfClones[groupName];
   }
 
   /**
@@ -2090,6 +2324,14 @@ class dollyProExtension {
     return true;
   }
 
+  initTheClone() {
+    return true;
+  }
+
+  beforeDeletionOfTheClone() {
+    return true;
+  }
+
   /**
    * 朝ID/分组/角色克隆体广播
    * @param {'ID'|'group'|'sprite'} MENU ID/group/sprite
@@ -2097,31 +2339,31 @@ class dollyProExtension {
    * @param {string} MSG 信息名
    * @param {*} data 附带信息
    */
-  broadcastToClone({ VALUE, MENU, MSG, data }, util) {
-    const targets = this._getClonesOfGroupOrSprite(MENU, Cast.toString(VALUE));
+  broadcastToClone({
+    VALUE, MENU, MSG, data,
+  }, util) {
+    const targets = this.getClonesOfGroupOrSprite(MENU, Cast.toString(VALUE));
     if (!targets || targets.length === 0) return;
     const senderID = this.getIDOfTarget(util.target);
     targets.forEach((target) => {
       util.startHatsWithParams(
-        'witCat.dollyPro_receiveMyBroadcast',
+        `${extensionId}_receiveMyBroadcast`,
         {
           parameters: { data, senderID },
           // 根据hat中的 TEXT 输入，过滤hat积木
           fields: { TEXT: Cast.toString(MSG) },
         },
-        target
+        target,
       );
     });
   }
-
 
   receiveMyBroadcast() {
     return true;
   }
 
-
   test(args) {
-    console.log('IDmap:', this._IDtoTargets);
+    console.log('IDmap:', this.IDtoTargets);
     console.log('targets:', this.runtime.targets);
     return Cast.toString(this.getTargetByID(args.ID));
   }
@@ -2135,23 +2377,26 @@ class dollyProExtension {
     const oldID = this.getIDOfTarget(util.target);
     // 旧ID和新ID一样，直接返回
     if (oldID === newID) {
-      console.warn(`多莉pro：修改的角色ID已经是${oldID}!`);
+      // TODO: l10n
+      console.warn(
+        this.formatMessage('warn.newIDIsOldID').replace('%s', oldID),
+      );
       return;
     }
     // ID重复
     if (this.getTargetByID(newID)) {
-      console.warn(
-        `多莉pro：已存在ID为${newID}的克隆体或角色，请不要设置相同 ID！`
-      );
+      alert(this.formatMessage('warn.repetitveID').replace('%s', newID));
       return;
     }
+    // eslint-disable-next-line no-param-reassign
     util.target.DollyPro.ID = newID;
-    this._IDtoTargets[newID] = this._IDtoTargets[oldID];
-    delete this._IDtoTargets[oldID];
+    this.IDtoTargets[newID] = this.IDtoTargets[oldID];
+    delete this.IDtoTargets[oldID];
     // 更新分组信息里的ID
-    Object.values(this._groupsOfClones).forEach((group) => {
+    Object.values(this.groupsOfClones).forEach((group) => {
       const idx = group.indexOf(oldID);
       if (idx !== -1) {
+        // eslint-disable-next-line no-param-reassign
         group[idx] = newID;
       }
     });
@@ -2161,13 +2406,13 @@ class dollyProExtension {
     const X = Cast.toString(X_NAME);
     const Y = Cast.toString(Y_NAME);
     const DIR = Cast.toString(DIR_NAME);
-    this._accessTransfer.x = X === '' ? null : X;
-    this._accessTransfer.y = Y === '' ? null : Y;
-    this._accessTransfer.direction = DIR === '' ? null : DIR;
+    this.accessTransfer.x = X === '' ? null : X;
+    this.accessTransfer.y = Y === '' ? null : Y;
+    this.accessTransfer.direction = DIR === '' ? null : DIR;
   }
 
   cancelAccessTransfer() {
-    this._accessTransfer = {};
+    this.accessTransfer = {};
   }
 
   // ************************ 普通积木 ************************
@@ -2184,36 +2429,35 @@ class dollyProExtension {
    * @param {'dis'|'dir'|'angle'|'absAngle'} MENU 计算菜单：dis/dir/angle/absAngle
    * @returns {number} 计算结果
    */
-  _calcInfoBetweenTargets(target1, target2, MENU) {
+  calcInfoBetweenTargets(target1, target2, MENU) {
     if (MENU === 'dis') {
-      return this._calcDistanceBetweenTargets(target1, target2);
+      return this.calcDistanceBetweenTargets(target1, target2);
     }
 
-    let dir = this._calcDirectionBetweenTargets(target1, target2);
+    const dir = this.calcDirectionBetweenTargets(target1, target2);
     if (MENU === 'dir') {
       return dir;
     }
-    let diff = this._calcDifferenceFromDir1ToDir2(target1.direction, dir);
+    const diff = this.calcDifferenceFromDir1ToDir2(target1.direction, dir);
     if (MENU === 'angle') return diff;
     return Math.abs(diff);
   }
 
-  _calcDirectionBetweenTargets(target1, target2) {
-    const [X1, Y1] = this._getTargetXYDir(target1, 'x', 'y');
-    const [X2, Y2] = this._getTargetXYDir(target2, 'x', 'y');
-    let dir =
-      (Math.atan((X2 - X1) / (Y2 - Y1)) / Math.PI) * 180 + (Y1 > Y2 ? 180 : 0);
+  calcDirectionBetweenTargets(target1, target2) {
+    const [X1, Y1] = this.getTargetXYDir(target1, 'x', 'y');
+    const [X2, Y2] = this.getTargetXYDir(target2, 'x', 'y');
+    let dir = (Math.atan((X2 - X1) / (Y2 - Y1)) / Math.PI) * 180 + (Y1 > Y2 ? 180 : 0);
     if (dir > 180) dir -= 360;
     return dir;
   }
 
-  _calcDistanceBetweenTargets(target1, target2) {
-    const [X1, Y1] = this._getTargetXYDir(target1, 'x', 'y');
-    const [X2, Y2] = this._getTargetXYDir(target2, 'x', 'y');
+  calcDistanceBetweenTargets(target1, target2) {
+    const [X1, Y1] = this.getTargetXYDir(target1, 'x', 'y');
+    const [X2, Y2] = this.getTargetXYDir(target2, 'x', 'y');
     return Math.sqrt((X2 - X1) ** 2 + (Y2 - Y1) ** 2);
   }
 
-  _calcDifferenceFromDir1ToDir2(dir1, dir2) {
+  calcDifferenceFromDir1ToDir2(dir1, dir2) {
     let dif = dir2 - dir1;
     dif -= Math.round(dif / 360) * 360;
     if (dif === -180) dif = 180;
@@ -2224,29 +2468,32 @@ class dollyProExtension {
   calcDistanceToClone({ ID, MENU }, util) {
     const target = this.getTargetByID(Cast.toString(ID));
     if (!target) return 0;
-    return this._calcInfoBetweenTargets(util.target, target, MENU);
+    return this.calcInfoBetweenTargets(util.target, target, MENU);
   }
+
   /** 计算ID1到ID2的距离/方向/角度差信息 */
   calcDistanceBetweenClones({ ID1, ID2, MENU }) {
     const target1 = this.getTargetByID(Cast.toString(ID1));
     if (!target1) return 0;
     const target2 = this.getTargetByID(Cast.toString(ID2));
     if (!target2) return 0;
-    return this._calcInfoBetweenTargets(target1, target2, MENU);
+    return this.calcInfoBetweenTargets(target1, target2, MENU);
   }
+
   /** 计算ID1到ID2的距离/方向/角度差信息 */
   moveToClone({ MOTION, ID }, util) {
     const target = this.getTargetByID(Cast.toString(ID));
     if (!target) return;
-    const [tx, ty] = this._getTargetXYDir(target, 'x', 'y');
+    const [tx, ty] = this.getTargetXYDir(target, 'x', 'y');
     if (MOTION === 'moveTo') {
-      this._setTargetXYDir(util.target, { x: ['set', tx], y: ['set', ty] });
+      this.setTargetXYDir(util.target, { x: ['set', tx], y: ['set', ty] });
     } else {
-      const dir = this._calcDirectionBetweenTargets(util.target, target);
+      const dir = this.calcDirectionBetweenTargets(util.target, target);
       if (dir.isNaN) return;
-      this._setTargetXYDir(util.target, { direction: ['set', dir] });
+      this.setTargetXYDir(util.target, { direction: ['set', dir] });
     }
   }
+
   /**
    * 朝target移动步数/旋转角度
    * @param {*} target
@@ -2254,50 +2501,51 @@ class dollyProExtension {
    * @param {number} velocity
    * @returns
    */
-  _moveStepsToTarget(target, MOTION, velocity, util) {
+  moveStepsToTarget(target, MOTION, velocity, util) {
     if (!target) return;
-    const [tx, ty] = this._getTargetXYDir(target, 'x', 'y');
+    const [tx, ty] = this.getTargetXYDir(target, 'x', 'y');
     if (MOTION === 'move') {
-      const dis = this._calcDistanceBetweenTargets(util.target, target);
+      const dis = this.calcDistanceBetweenTargets(util.target, target);
       if (dis <= velocity) {
         // 距离比移动距离小，直接移到目标
-        this._setTargetXYDir(util.target, { x: ['set', tx], y: ['set', ty] });
+        this.setTargetXYDir(util.target, { x: ['set', tx], y: ['set', ty] });
       } else {
         // 否则，朝目标位置移动
-        const [myX, myY] = this._getTargetXYDir(util.target, 'x', 'y');
+        const [myX, myY] = this.getTargetXYDir(util.target, 'x', 'y');
         const dx = ((tx - myX) * velocity) / dis;
         const dy = ((ty - myY) * velocity) / dis;
-        this._setTargetXYDir(util.target, {
+        this.setTargetXYDir(util.target, {
           x: ['change', dx],
           y: ['change', dy],
         });
       }
     } else {
-      const dir = this._calcDirectionBetweenTargets(util.target, target);
+      const dir = this.calcDirectionBetweenTargets(util.target, target);
       if (dir.isNaN) return;
-      const myDir = this._getTargetXYDir(util.target, 'direction');
-      const diff = this._calcDifferenceFromDir1ToDir2(myDir, dir);
+      const myDir = this.getTargetXYDir(util.target, 'direction');
+      const diff = this.calcDifferenceFromDir1ToDir2(myDir, dir);
       if (Math.abs(diff) <= velocity) {
         // 角度差比转速小，直接面向目标
-        this._setTargetXYDir(util.target, { direction: ['set', dir] });
+        this.setTargetXYDir(util.target, { direction: ['set', dir] });
       } else {
         // 否则，朝目标旋转
-        this._setTargetXYDir(util.target, {
+        this.setTargetXYDir(util.target, {
           direction: ['change', diff > 0 ? velocity : -velocity],
         });
       }
     }
   }
+
   /** 朝克隆体移动步数/旋转角度 */
   moveStepsToClone({ ID, MOTION, VALUE }, util) {
     const target = this.getTargetByID(Cast.toString(ID));
     const velocity = Cast.toNumber(VALUE);
     if (!target) return;
-    this._moveStepsToTarget(target, MOTION, velocity, util);
+    this.moveStepsToTarget(target, MOTION, velocity, util);
   }
 
   presetGroupForTheNextClone({ GROUP }) {
-    this._clonePresetGroups[String(GROUP)] = true;
+    this.clonePresetGroups[String(GROUP)] = true;
   }
 
   cloneIDOfForEach(args, util) {
@@ -2312,10 +2560,12 @@ class dollyProExtension {
     if (times === 0) return;
 
     if (typeof util.stackFrame.loopCounter === 'undefined') {
+      // eslint-disable-next-line no-param-reassign
       util.stackFrame.loopCounter = times;
     }
 
-    util.stackFrame.loopCounter--;
+    // eslint-disable-next-line no-param-reassign
+    util.stackFrame.loopCounter -= 1;
     const idx = times - util.stackFrame.loopCounter - 1;
     if (idx > times - 1) return;
     this.forEachIndex[util.thread.topBlock] = groupList[idx];
@@ -2331,54 +2581,55 @@ class dollyProExtension {
    * @param {string} VALUE ID/组名/角色名
    * @returns {[ITarget]|undefined} target表
    */
-  _getClonesOfGroupOrSprite(MENU, VALUE) {
+  getClonesOfGroupOrSprite(MENU, VALUE) {
     switch (MENU) {
       case 'ID': {
         const target = this.getTargetByID(VALUE);
-        if (!target) return;
+        if (!target) return undefined;
         return [target];
       }
       case 'group': {
         const IDs = this.getGroupByName(VALUE);
-        if (!IDs) return;
+        if (!IDs) return undefined;
         return IDs.map((ID) => this.getTargetByID(ID));
       }
       case 'sprite': {
         const sprite = this.runtime.getSpriteTargetByName(VALUE);
-        if (!sprite || sprite.isStage) return;
+        if (!sprite || sprite.isStage) return undefined;
         return sprite.sprite.clones;
         // return sprite.sprite.clones.filter((target) => {
         //   return !target.isOriginal;
         // });
       }
       default:
-        return;
+        return undefined;
     }
   }
 
   getNearestClone({ MENU, VALUE, TYPE }, util) {
-    const targets = this._getClonesOfGroupOrSprite(MENU, Cast.toString(VALUE));
+    const targets = this.getClonesOfGroupOrSprite(MENU, Cast.toString(VALUE));
     if (!targets) return '';
     let closestID = '';
     const isNear = TYPE === 'nearest';
     let minDistance = Infinity;
 
-    for (const target of targets) {
-      if (target === util.target) continue;
-      let distance = this._calcDistanceBetweenTargets(util.target, target);
-      // 求最远距离，则反转
-      if (!isNear) distance *= -1;
+    targets.forEach((target) => {
+      if (target !== util.target) {
+        let distance = this.calcDistanceBetweenTargets(util.target, target);
+        // 求最远距离，则反转
+        if (!isNear) distance *= -1;
 
-      if (distance < minDistance) {
-        minDistance = distance;
-        closestID = this.getIDOfTarget(target);
+        if (distance < minDistance) {
+          minDistance = distance;
+          closestID = this.getIDOfTarget(target);
+        }
       }
-    }
+    });
     return closestID;
   }
 
   /** Scratch坐标转换为Client坐标 */
-  _ScratchXYToClientXY(x, y) {
+  ScratchXYToClientXY(x, y) {
     let canvasHeight = 0;
     let canvasWidth = 0;
     if (this.canvas) {
@@ -2386,36 +2637,29 @@ class dollyProExtension {
       canvasHeight = rect.height;
       canvasWidth = rect.width;
     }
-    x = (x / this.runtime.stageWidth + 0.5) * canvasWidth;
-    y = (-y / this.runtime.stageHeight + 0.5) * canvasHeight;
-    return [x, y];
+    const x2 = (x / this.runtime.stageWidth + 0.5) * canvasWidth;
+    const y2 = (-y / this.runtime.stageHeight + 0.5) * canvasHeight;
+    return [x2, y2];
   }
 
-  isCloneTouchingCoord({ X, Y, MENU, VALUE }) {
-    const targets = this._getClonesOfGroupOrSprite(MENU, Cast.toString(VALUE));
+  isCloneTouchingCoord({
+    X, Y, MENU, VALUE,
+  }) {
+    const targets = this.getClonesOfGroupOrSprite(MENU, Cast.toString(VALUE));
     if (!targets) return false;
-    const renderer = this.runtime.renderer;
-    const [x, y] = this._ScratchXYToClientXY(
-      Cast.toNumber(X),
-      Cast.toNumber(Y)
-    );
-    for (const target of targets) {
-      if (renderer.drawableTouching(target.drawableID, x, y)) return true;
-    }
-    return false;
+    const { renderer } = this.runtime;
+    const [x, y] = this.ScratchXYToClientXY(Cast.toNumber(X), Cast.toNumber(Y));
+    return targets.some((target) => renderer.drawableTouching(target.drawableID, x, y));
   }
 
   /** 获取XY处最顶层角色或克隆体ID */
   pickTarget({ X, Y }) {
-    const renderer = this.runtime.renderer;
-    const [x, y] = this._ScratchXYToClientXY(
-      Cast.toNumber(X),
-      Cast.toNumber(Y)
-    );
+    const { renderer } = this.runtime;
+    const [x, y] = this.ScratchXYToClientXY(Cast.toNumber(X), Cast.toNumber(Y));
     if (renderer) {
       const drawableID = renderer.pick(x, y);
       if (!drawableID) return '';
-      for (let i = 0; i < this.runtime.targets.length; i++) {
+      for (let i = 0; i < this.runtime.targets.length; i += 1) {
         const target = this.runtime.targets[i];
         if (target.drawableID === drawableID) {
           return this.getIDOfTarget(target);
@@ -2432,11 +2676,11 @@ class dollyProExtension {
    * @param {string} VALUE
    * @returns
    */
-  _targetTouchingClone(target, MENU, VALUE) {
-    let targets = this._getClonesOfGroupOrSprite(MENU, Cast.toString(VALUE));
+  targetTouchingClone(target, MENU, VALUE) {
+    const targets = this.getClonesOfGroupOrSprite(MENU, Cast.toString(VALUE));
     if (!targets) return false;
 
-    const renderer = this.runtime.renderer;
+    const { renderer } = this.runtime;
     // // 检测角色时，只检测克隆体
     // if (MENU === 'sprite') {
     //   targets = targets.filter((target) => {
@@ -2450,58 +2694,60 @@ class dollyProExtension {
   isCloneTouchingClone({ ID, MENU, VALUE }) {
     const target = this.getTargetByID(Cast.toString(ID));
     if (!target) return false;
-    return this._targetTouchingClone(target, MENU, VALUE);
+    return this.targetTouchingClone(target, MENU, VALUE);
   }
 
   isTouchingClone({ MENU, VALUE }, util) {
-    return this._targetTouchingClone(util.target, MENU, VALUE);
+    return this.targetTouchingClone(util.target, MENU, VALUE);
   }
 
-  _getTouchingID(targets, TYPE, util) {
-    const renderer = this.runtime.renderer;
+  // eslint-disable-next-line no-underscore-dangle
+  actualGetTouchingID(targets, TYPE, util) {
+    const { renderer } = this.runtime;
 
-    let IDs = [];
-    for (const target of targets) {
-      if (target === util.target) continue;
-      // 碰到对方
-      if (
-        renderer.isTouchingDrawables(util.target.drawableID, [
-          target.drawableID,
-        ])
-      ) {
-        const ID = this.getIDOfTarget(target);
-        if (TYPE === 'one') {
-          return ID;
-        } else {
+    const IDs = [];
+    for (let i = 0; i < targets.length; i += 1) {
+      const target = targets[i];
+      if (target !== util.target) {
+        // 碰到对方
+        if (
+          renderer.isTouchingDrawables(util.target.drawableID, [
+            target.drawableID,
+          ])
+        ) {
+          const ID = this.getIDOfTarget(target);
+          if (TYPE === 'one') {
+            return ID;
+          }
           IDs.push(ID);
         }
       }
     }
     if (TYPE === 'one') {
       return '';
-    } else {
-      return IDs;
     }
+    return IDs;
   }
 
   getTouchingID({ MENU, VALUE, TYPE }, util) {
-    let targets = this._getClonesOfGroupOrSprite(MENU, Cast.toString(VALUE));
+    const targets = this.getClonesOfGroupOrSprite(MENU, Cast.toString(VALUE));
     if (!targets) return TYPE === 'one' ? '' : '[]';
-    const res = this._getTouchingID(targets, TYPE, util);
+    const res = this.actualGetTouchingID(targets, TYPE, util);
     if (TYPE === 'one') {
       return res;
-    } else {
-      return JSON.stringify(res);
     }
+    return JSON.stringify(res);
   }
 
-  importTouchingIDsIntoList({ MENU, VALUE, OP, LIST }, util) {
+  importTouchingIDsIntoList({
+    MENU, VALUE, OP, LIST,
+  }, util) {
     let list = LIST;
     if (typeof list === 'object') list = list.name;
-    let targets = this._getClonesOfGroupOrSprite(MENU, Cast.toString(VALUE));
+    let targets = this.getClonesOfGroupOrSprite(MENU, Cast.toString(VALUE));
     if (!targets) targets = [];
-    const res = this._getTouchingID(targets, 'all', util);
-    this._importArrayIntoScratchList(res, OP, list, util);
+    const res = this.actualGetTouchingID(targets, 'all', util);
+    this.importArrayIntoScratchList(res, OP, list, util);
   }
   // --------
 
@@ -2553,17 +2799,15 @@ class dollyProExtension {
     if (idx < 1 || idx > groupList.length) return '';
     const target = this.getTargetByID(groupList[idx - 1]);
     if (!target) return '';
-    return this.__propertyOfTarget(target, PROPERTY);
+    return this.propertyOfTarget(target, PROPERTY);
   }
 
-  _importArrayIntoScratchList(array, OP, LIST, util) {
+  importArrayIntoScratchList(array, OP, LIST, util) {
     if (LIST === 'empty') return;
     let list = util.target.lookupVariableById(LIST);
-    if (
-      (!list && (list = util.target.lookupVariableByNameAndType(LIST, 'list')),
-      list === undefined)
-    )
-      return;
+    if (!list) return;
+    list = util.target.lookupVariableByNameAndType(LIST, 'list');
+    if (!list) return;
 
     if (OP === 'replace') {
       if (array) {
@@ -2582,7 +2826,7 @@ class dollyProExtension {
     if (typeof list === 'object') list = list.name;
     if (list === 'empty') return;
     const groupList = this.getGroupByName(Cast.toString(GROUP));
-    this._importArrayIntoScratchList(groupList, OP, list, util);
+    this.importArrayIntoScratchList(groupList, OP, list, util);
   }
 
   /**
@@ -2602,16 +2846,18 @@ class dollyProExtension {
    * @param {string|number|boolean} args.VALUE 值
    */
   presetPropertyForTheNextClone(args) {
-    this._clonePresetProperties[args.PROPERTY] = args.VALUE;
+    this.clonePresetProperties[args.PROPERTY] = args.VALUE;
   }
+
   /**
    * 预设克隆体单条数据KEY
    * @param {string} args.KEY 预设KEY
    * @param {string|number|boolean} args.VALUE 值
    */
   presetSingleDataForTheNextClone(args) {
-    this._clonePresetData[String(args.KEY)] = args.VALUE;
+    this.clonePresetData[String(args.KEY)] = args.VALUE;
   }
+
   /**
    * 预设克隆体数据JSON
    * @param {string} args.DATA_JSON 预设JSON
@@ -2620,7 +2866,7 @@ class dollyProExtension {
     try {
       const obj = JSON.parse(Cast.toString(args.DATA_JSON));
       if (typeof obj === 'object' && obj !== null && !Array.isArray(obj)) {
-        this._clonePresetData = obj;
+        this.clonePresetData = obj;
       } else {
         console.warn('Dolly pro: Preseting clone JSON data fails.');
       }
@@ -2635,8 +2881,9 @@ class dollyProExtension {
    * @param {string} prop 属性名
    * @param {'set'|'change'} op 操作set/change
    * @param {*} v 值
+   * @private
    */
-  __opPropertyOfTarget(target, prop, op, v) {
+  opPropertyOfTarget(target, prop, op, v) {
     const numberV = Cast.toNumber(v);
     const isChanging = op === 'change';
     switch (prop) {
@@ -2654,7 +2901,7 @@ class dollyProExtension {
         return;
       case 'visible':
         target.setVisible(
-          Cast.toBoolean(isChanging * target.visible + numberV)
+          Cast.toBoolean(isChanging * target.visible + numberV),
         );
         return;
       case 'currentCostumeName':
@@ -2677,21 +2924,21 @@ class dollyProExtension {
       case 'ghost':
       case 'mosaic': {
         let value = numberV + isChanging * target.effects[prop];
-        value = this.__clampEffect(prop, value);
+        value = this.clampEffect(prop, value);
         target.setEffect(prop, value);
-        return;
+        break;
       }
       default:
-        return;
     }
   }
+
   /** clamp特效值，限制在正确范围内 */
-  __clampEffect(effect, value) {
+  clampEffect(effect, value) {
     switch (effect) {
       case 'ghost':
-        return this.__clamp(value, 0, 100);
+        return this.clamp(value, 0, 100);
       case 'brightness':
-        return this.__clamp(value, -100, 100);
+        return this.clamp(value, -100, 100);
       default:
         return value;
     }
@@ -2703,7 +2950,7 @@ class dollyProExtension {
    * @param {string} args.ID 指定的ID
    */
   createCloneAndSpecifyID(args, util) {
-    let TARGET = Cast.toString(args.TARGET);
+    const TARGET = Cast.toString(args.TARGET);
     let specifyingID = Cast.toString(args.ID);
 
     // 获取要克隆的target
@@ -2719,21 +2966,17 @@ class dollyProExtension {
     const newClone = cloneTarget.makeClone();
 
     if (newClone) {
-      // 未指定 ID，则默认使用VM id
+      // 未指定 ID
       if (specifyingID === '') {
-        specifyingID = newClone.id;
+        specifyingID = undefined;
       } else if (
-        Object.prototype.hasOwnProperty.call(this._IDtoTargets, specifyingID)
+        Object.prototype.hasOwnProperty.call(this.IDtoTargets, specifyingID)
       ) {
         // 如果已经存在相同 ID
-        console.error(
-          '多莉pro: 已经存在ID为"' +
-            specifyingID +
-            '"的克隆体，克隆时请勿使用相同ID！\nDolly pro: There is already a clone with the ID"' +
-            specifyingID +
-            '". Please do not use the same ID when cloning!'
+        alert(
+          this.formatMessage('error.repetitiveID').replace('%s', specifyingID),
         );
-        specifyingID = newClone.id;
+        specifyingID = undefined;
       }
       // 注入dolly并设置ID
       this.injectDollyTarget(newClone, specifyingID);
@@ -2750,7 +2993,7 @@ class dollyProExtension {
    */
   deleteCloneByID(args) {
     const ID = Cast.toString(args.ID);
-    let target = this.getTargetByID(ID);
+    const target = this.getTargetByID(ID);
     if (target) {
       if (target.isOriginal) return;
       this.runtime.disposeTarget(target);
@@ -2765,15 +3008,17 @@ class dollyProExtension {
    * @returns {string|number|boolean} 克隆体的KEY对应数据
    */
   getValueOfCloneIDWithKey(args) {
-    let target = this.getTargetByID(Cast.toString(args.ID));
+    const target = this.getTargetByID(Cast.toString(args.ID));
     if (!target) return '';
-    return this.__getDataOfTarget(target, Cast.toString(args.KEY));
+    return this.getDataOfTarget(target, Cast.toString(args.KEY));
   }
+
   getMyValueByKey(args, util) {
-    return this.__getDataOfTarget(util.target, Cast.toString(args.KEY));
+    return this.getDataOfTarget(util.target, Cast.toString(args.KEY));
   }
-  __getDataOfTarget(target, key) {
-    let data = this.getExtraDataOfTarget(target);
+
+  getDataOfTarget(target, key) {
+    const data = this.getExtraDataOfTarget(target);
     return data[key] ?? '';
   }
 
@@ -2785,9 +3030,9 @@ class dollyProExtension {
    * @param {*} args.VALUE 值
    */
   setCloneProperty(args) {
-    let target = this.getTargetByID(Cast.toString(args.ID));
+    const target = this.getTargetByID(Cast.toString(args.ID));
     if (!target) return;
-    this.__opPropertyOfTarget(target, args.PROPERTY, args.OP, args.VALUE);
+    this.opPropertyOfTarget(target, args.PROPERTY, args.OP, args.VALUE);
   }
 
   /**
@@ -2798,25 +3043,27 @@ class dollyProExtension {
    * @param {*} args.VALUE 值
    */
   setOrChangeValueOfCloneIDWithKey(args) {
-    let target = this.getTargetByID(Cast.toString(args.ID));
+    const target = this.getTargetByID(Cast.toString(args.ID));
     if (!target) return;
-    this.__setOrChangeDataOfTarget(
+    this.setOrChangeDataOfTarget(
       target,
       Cast.toString(args.KEY),
       args.OP,
-      args.VALUE
+      args.VALUE,
     );
   }
+
   setOrChangeMyValueWithKey(args, util) {
-    this.__setOrChangeDataOfTarget(
+    this.setOrChangeDataOfTarget(
       util.target,
       Cast.toString(args.KEY),
       args.OP,
-      args.VALUE
+      args.VALUE,
     );
   }
-  __setOrChangeDataOfTarget(target, key, op, value) {
-    let data = this.getExtraDataOfTarget(target);
+
+  setOrChangeDataOfTarget(target, key, op, value) {
+    const data = this.getExtraDataOfTarget(target);
     if (op === 'set') {
       data[key] = value;
     } else {
@@ -2825,15 +3072,16 @@ class dollyProExtension {
   }
 
   getMyProperty(args, util) {
-    return this.__propertyOfTarget(util.target, args.PROPERTY);
-  }
-  getClonePropertyWithID(args) {
-    let target = this.getTargetByID(Cast.toString(args.ID));
-    if (!target) return '';
-    return this.__propertyOfTarget(target, args.PROPERTY);
+    return this.propertyOfTarget(util.target, args.PROPERTY);
   }
 
-  __propertyOfTarget(target, type) {
+  getClonePropertyWithID(args) {
+    const target = this.getTargetByID(Cast.toString(args.ID));
+    if (!target) return '';
+    return this.propertyOfTarget(target, args.PROPERTY);
+  }
+
+  propertyOfTarget(target, type) {
     switch (type) {
       case 'currentCostume':
         return target.currentCostume + 1;
@@ -2842,10 +3090,10 @@ class dollyProExtension {
       case 'name':
         return target.sprite.name;
       case 'id':
-        //获取 ID 时，返回虚拟ID
+        // 获取 ID 时，返回虚拟ID
         return this.getIDOfTarget(target);
       case 'dataJSON':
-        //获取KV数据JSON
+        // 获取KV数据JSON
         return JSON.stringify(this.getExtraDataOfTarget(target));
       case 'color':
       case 'fisheye':
@@ -2861,12 +3109,14 @@ class dollyProExtension {
   }
 
   getCloneTargetPropertyWithSpriteName(args) {
-    const targets = this.runtime.targets.filter((target) => {
-      return (
-        !target.isOriginal &&
-        (args.TARGET !== '_all_' ? target.sprite.name === args.TARGET : true)
-      );
-    });
+    return this.getCloneTargetPropertyWithSpriteName2(args);
+  }
+
+  getCloneTargetPropertyWithSpriteName2(args) {
+    const targets = this.runtime.targets.filter(
+      (target) => !target.isOriginal
+        && (args.TARGET !== '_all_' ? target.sprite.name === args.TARGET : true),
+    );
     let value;
     switch (args.PROPERTY) {
       case 'count':
@@ -2877,7 +3127,7 @@ class dollyProExtension {
         break;
       case 'IDList':
         value = JSON.stringify(
-          targets.map((target) => this.getIDOfTarget(target))
+          targets.map((target) => this.getIDOfTarget(target)),
         );
         break;
       default:
@@ -2888,9 +3138,13 @@ class dollyProExtension {
   }
 
   getOriginalTargetPropertyWithSpriteName(args) {
+    return this.getOriginalTargetPropertyWithSpriteName2(args);
+  }
+
+  getOriginalTargetPropertyWithSpriteName2(args) {
     const target = this.runtime.getSpriteTargetByName(args.TARGET);
     if (!target) return '';
-    return this.__propertyOfTarget(target, args.PROPERTY);
+    return this.propertyOfTarget(target, args.PROPERTY);
   }
 }
 
@@ -2902,6 +3156,8 @@ window.tempExt = {
     extensionId,
     iconURL: cover,
     insetIconURL: icon,
+    docsURI:
+      'https://learn.ccw.site/article/9b9b43cd-75c3-4271-998c-b7c250fc81b9',
     featured: true,
     disabled: false,
     collaborator: 'editor @ dollyProTeam',


### PR DESCRIPTION
fix: 修复dollyPro和旧dolly不兼容的bug; 修复重复劫持导致作品加载失败的bug
refactor: 引入window.Scratch; 修改canvas获取方式
refactor: 换掉了for...in/of...
style: 移除类属性名前面的下划线
style: 补充注释; 整理代码;
feat: 两个积木菜单现在可以塞入积木（不能塞入菜单的旧积木隐藏）
feat: 添加在舞台注释中保存扩展信息的功能(保存”是否显示更多积木“)
docs: 补充文档链接（还没写内容，之后更新）