### PR TITLE
Create var-and-list.js

### DIFF
--- a/qxsck/var-and-list.js
+++ b/qxsck/var-and-list.js
@@ -1046,12 +1046,8 @@ class VarAndList {
     if (list && list2) {
       try{
         let object=JSON.parse(args.OBJ);
-        list.value=[];
-        list2.value=[];
-        for(let key in object){
-          list.value.push(key);
-          list2.value.push(object[key]);
-        }
+        list.value=Object.keys(object);
+        list2.value=Object.values(object);
         list._monitorUpToDate = false;
         list2._monitorUpToDate = false;
       }catch(error){

--- a/qxsck/var-and-list.js
+++ b/qxsck/var-and-list.js
@@ -479,6 +479,8 @@ class VarAndList {
           }
         },
 
+        '---',
+        
         {
           opcode:'forEach',
           blockType: 'conditional',

--- a/qxsck/var-and-list.js
+++ b/qxsck/var-and-list.js
@@ -90,7 +90,7 @@ class VarAndList {
         'qxsckvarandlist.sortList': 'sort list [LIST] with [CASE]',
         'qxsckvarandlist.sortListRange': 'sort from [LEFT] to [RIGHT] in list [LIST] with [CASE]',
 
-        'qxsckvarandlist.unSupportCompile': '⚠️unsupport complied',
+        'qxsckvarandlist.unSupportCompile': '⚠️unsupport complie',
         
         'qxsckvarandlist.forEach': '⚠️for each variable [VAR] from [LEFT] to [RIGHT]',
         'qxsckvarandlist.forEachList': '⚠️for each variable [VAR] in value of from [LEFT] to [RIGHT] in list [LIST]',

--- a/qxsck/var-and-list.js
+++ b/qxsck/var-and-list.js
@@ -52,8 +52,10 @@ class VarAndList {
         'qxsckvarandlist.sortListRange': '以 [CASE] 排序列表 [LIST] 的第 [LEFT] 到 [RIGHT] 项',
         'qxsckvarandlist.mapObject': '映射对象 [OBJ] 的值到列表 [LIST] ，键到列表 [LIST2]',
 
-        'qxsckvarandlist.forEach': '对于从 [LEFT] 到 [RIGHT] 中的每个变量 [VAR]',
-        'qxsckvarandlist.forEachList': '对于列表 [LIST] 中从第 [LEFT] 到第 [RIGHT] 项的每个变量 [VAR]',
+        'qxsckvarandlist.unSupportCompile': '⚠️不支持编译',
+
+        'qxsckvarandlist.forEach': '⚠️对于从 [LEFT] 到 [RIGHT] 中的每个变量 [VAR]',
+        'qxsckvarandlist.forEachList': '⚠️对于列表 [LIST] 中从第 [LEFT] 到第 [RIGHT] 项的每个变量 [VAR]',
       },
       en: {
         'qxsckvarandlist.name': 'variable and list',
@@ -98,8 +100,10 @@ class VarAndList {
         'qxsckvarandlist.sortListRange': 'sort from [LEFT] to [RIGHT] in list [LIST] with [CASE]',
         'qxsckvarandlist.mapObject': 'map object [OBJ] to list [LIST],key to list [LIST2]',
 
-        'qxsckvarandlist.forEach': 'for each variable [VAR] from [LEFT] to [RIGHT]',
-        'qxsckvarandlist.forEachList': 'for each variable [VAR] in value of from [LEFT] to [RIGHT] in list [LIST]',
+        'qxsckvarandlist.unSupportCompile': '⚠️Compilation not supported',
+
+        'qxsckvarandlist.forEach': '⚠️for each variable [VAR] from [LEFT] to [RIGHT]',
+        'qxsckvarandlist.forEachList': '⚠️for each variable [VAR] in value of from [LEFT] to [RIGHT] in list [LIST]',
       },
     });
   }
@@ -585,7 +589,7 @@ class VarAndList {
           }
         },
 
-        '---',
+        '---'+this.formatMessage('qxsckvarandlist.unSupportCompile'),
 
         {
           opcode:'forEach',
@@ -854,7 +858,7 @@ class VarAndList {
     try{
       let arr=JSON.parse(args.LIST2);
       variable.value.splice(index-1,0,...arr);
-    variable._monitorUpToDate = false;
+      variable._monitorUpToDate = false;
     }catch(error){
       console.log('error:', error);
     }

--- a/qxsck/var-and-list.js
+++ b/qxsck/var-and-list.js
@@ -15,6 +15,10 @@ class VarAndList {
         'qxsckvarandlist.open': '打开',
         'qxsckvarandlist.close': '关闭',
 
+        'qxsckvarandlist.asc': '升序',
+        'qxsckvarandlist.desc': '降序',
+        'qxsckvarandlist.dictOrder': '字典序',
+
         'qxsckvarandlist.haveVar': '有变量 [VAR] 吗？',
         'qxsckvarandlist.getVar': '变量 [VAR] 的值',
         'qxsckvarandlist.setVar': '将变量 [VAR] 的值设置为 [VALUE]',
@@ -40,15 +44,21 @@ class VarAndList {
         'qxsckvarandlist.listContains': '列表 [LIST] 包括 [VALUE] 吗？',
         'qxsckvarandlist.copyList': '将列表 [LIST1] 复制到列表 [LIST2]',
         'qxsckvarandlist.reverseList': '反转列表 [LIST]',
+        'qxsckvarandlist.sortList': '以 [CASE] 排序列表 [LIST]',
+        'qxsckvarandlist.sortListRange': '以 [CASE] 排序列表 [LIST] 的第 [LEFT] 到 [RIGHT] 项',
 
         'qxsckvarandlist.forEach': '对于从 [LEFT] 到 [RIGHT] 中的每个变量 [VAR]',
         'qxsckvarandlist.forEachList': '对于列表 [LIST] 中从第 [LEFT] 到第 [RIGHT] 项的每个变量 [VAR]',
       },
       en: {
-        'qxsckvarandlist.name': 'var and list',
+        'qxsckvarandlist.name': 'variable and list',
 
         'qxsckvarandlist.open': 'open',
         'qxsckvarandlist.close': 'close',
+
+        'qxsckvarandlist.asc': 'ascending',
+        'qxsckvarandlist.desc': 'descending',
+        'qxsckvarandlist.dictOrder': 'dictionary order',
 
         'qxsckvarandlist.haveVar': 'have variable [VAR] ?',
         'qxsckvarandlist.getVar': 'value of variable [VAR]',
@@ -75,6 +85,8 @@ class VarAndList {
         'qxsckvarandlist.listContains': 'list [LIST] have [VALUE] ?',
         'qxsckvarandlist.copyList': 'copy list [LIST1] to list [LIST2]',
         'qxsckvarandlist.reverseList': 'reverse lsit [LIST]',
+        'qxsckvarandlist.sortList': 'sort list [LIST] with [CASE]',
+        'qxsckvarandlist.sortListRange': 'sort from [LEFT] to [RIGHT] in list [LIST] with [CASE]',
 
         'qxsckvarandlist.forEach': 'for each variable [VAR] from [LEFT] to [RIGHT]',
         'qxsckvarandlist.forEachList': 'for each variable [VAR] in value of from [LEFT] to [RIGHT] in list [LIST]',
@@ -426,6 +438,44 @@ class VarAndList {
               type: 'string',
               defaultValue:'list'
             },
+          },
+        },
+        {
+          opcode:'sortList',
+          blockType: 'command',
+          text: this.formatMessage('qxsckvarandlist.sortList'),
+          arguments: {
+            LIST: {
+              type: 'string',
+              defaultValue:'list'
+            },
+            CASE:{
+              type: 'string',
+              menu: 'sortList.List',
+            }
+          }
+        },
+        {
+          opcode:'sortListRange',
+          blockType: 'command',
+          text: this.formatMessage('qxsckvarandlist.sortListRange'),
+          arguments: {
+            LIST: {
+              type: 'string',
+              defaultValue:'list'
+            },
+            CASE:{
+              type: 'string',
+              menu: 'sortList.List',
+            },
+            LEFT: {
+              type: 'string',
+              defaultValue:'1'
+            },
+            RIGHT: {
+              type: 'string',
+              defaultValue:'2'
+            },
           }
         },
 
@@ -481,6 +531,20 @@ class VarAndList {
           {
             text: this.formatMessage("qxsckvarandlist.close"),
             value: 'close'
+          },
+        ],
+        'sortList.List':[
+          {
+            text: this.formatMessage("qxsckvarandlist.asc"),
+            value: 'asc'
+          },
+          {
+            text: this.formatMessage("qxsckvarandlist.desc"),
+            value: 'desc'
+          },
+          {
+            text: this.formatMessage("qxsckvarandlist.dictOrder"),
+            value: 'dictOrder'
           },
         ],
       }
@@ -647,8 +711,8 @@ class VarAndList {
     const variable = util.target.lookupVariableByNameAndType(String(args.LIST), 'list'),list2=String(args.LIST2);
     if (variable) {
       try {
-        var arr = JSON.parse(list2);
-        for (var i = 0; i < arr.length; i++) {
+        let arr = JSON.parse(list2);
+        for (let i = 0; i < arr.length; i++) {
           variable.value.push(arr[i]);
         }
         variable._monitorUpToDate = false;
@@ -674,7 +738,7 @@ class VarAndList {
     const value = args.VALUE;
     let flag=openCaseSensitive;
     if (variable) {
-      for (var i = 0; i < variable.value.length; i++) {
+      for (let i = 0; i < variable.value.length; i++) {
         if(!flag){
           if (Scratch.Cast.compare(variable.value[i], value) === 0) return i + 1;
         }else{
@@ -690,8 +754,8 @@ class VarAndList {
     const value = args.VALUE;
     let flag=openCaseSensitive;
     if (variable) {
-      var indexes = [];
-      for (var i = 0; i < variable.value.length; i++) {
+      let indexes = [];
+      for (let i = 0; i < variable.value.length; i++) {
         if(!flag){
           if (Scratch.Cast.compare(variable.value[i], value) === 0) indexes.push(i + 1);
         }else{
@@ -708,8 +772,8 @@ class VarAndList {
     const value = args.VALUE;
     let flag=openCaseSensitive;
     if (variable) {
-      var indexes = [];
-      for (var i = 0; i < variable.value.length; i++) {
+      let indexes = [];
+      for (let i = 0; i < variable.value.length; i++) {
         if(!flag){
           if (Scratch.Cast.compare(variable.value[i], value) === 0) indexes.push(i + 1);
         }else{
@@ -726,8 +790,8 @@ class VarAndList {
     const value = args.VALUE;
     let flag=openCaseSensitive;
     if (variable) {
-      var indexes = [];
-      for (var i = 0; i < variable.value.length; i++) {
+      let indexes = [];
+      for (let i = 0; i < variable.value.length; i++) {
         if(!flag){
           if (Scratch.Cast.compare(variable.value[i], value) === 0) indexes.push(i + 1);
         }else{
@@ -744,7 +808,7 @@ class VarAndList {
     const value = args.VALUE;
     let flag=openCaseSensitive;
     if (variable) {
-      for (var i = 0;i < variable.value.length;i++) {
+      for (let i = 0;i < variable.value.length;i++) {
         if(!flag){
           if (Scratch.Cast.compare(variable.value[i], value) === 0) return true;
         }else{
@@ -768,9 +832,55 @@ class VarAndList {
     /** @type {VM.ListVariable} */
     const variable = util.target.lookupVariableByNameAndType(String(args.LIST), 'list');
     if (variable) {
-      var list=variable.value.slice();
+      let list=variable.value.slice();
       list.reverse();
       variable.value=list;
+      variable._monitorUpToDate = false;
+    }
+  }
+  sortList(args,util){
+    const variable = util.target.lookupVariableByNameAndType(String(args.LIST), 'list');
+    let order=String(args.CASE);
+    if (variable) {
+      let list=variable.value.slice();
+      if(order==='asc'){
+        list=list.map(val=>isNaN(Number(val))?0:Number(val));
+        variable.value=list.sort((a,b)=>a-b);
+      }
+      else if(order==='desc'){
+        list=list.map(val=>isNaN(Number(val))?0:Number(val));
+        variable.value=list.sort((a,b)=>b-a);
+      }
+      else if(order==='dictOrder'){
+        list=list.map(val=>String(val));
+        variable.value=list.sort();
+      }
+      variable._monitorUpToDate = false;
+    }
+  }
+  sortListRange(args,util){
+    const variable = util.target.lookupVariableByNameAndType(String(args.LIST), 'list');
+    let order=String(args.CASE);
+    if (variable) {
+      let length=variable.value.length,left=Number(args.LEFT),right=Number(args.RIGHT);
+      if(left<1) left=1;
+      if(right>length) right=length;
+      left-=1,right-=1;
+      let list=variable.value.slice(left,right+1);
+      if(order==='asc'){
+        list=list.map(val=>isNaN(Number(val))?0:Number(val));
+        list=list.sort((a,b)=>a-b);
+      }
+      else if(order==='desc'){
+        list=list.map(val=>isNaN(Number(val))?0:Number(val));
+        list=list.sort((a,b)=>b-a);
+      }
+      else if(order==='dictOrder'){
+        list=list.map(val=>String(val));
+        list=list.sort();
+      }
+      let list2=variable.value.slice();
+      variable.value=[...list2.slice(0,left),...list,...list2.slice(right+1,length)];
       variable._monitorUpToDate = false;
     }
   }

--- a/qxsck/var-and-list.js
+++ b/qxsck/var-and-list.js
@@ -24,6 +24,8 @@ class VarAndList {
         'qxsckvarandlist.haveList': '有列表 [LIST] 吗？',
         'qxsckvarandlist.length': '列表 [LIST] 的长度',
         'qxsckvarandlist.getList': '列表 [LIST] 的值',
+        'qxsckvarandlist.newGetList': '列表 [LIST] 的值',
+        'qxsckvarandlist.getListRange': '列表 [LIST] 中第 [LEFT] 到 [RIGHT] 项的值',
         'qxsckvarandlist.getValueOfList': '列表 [LIST] 的第 [INDEX] 项',
         'qxsckvarandlist.seriListsToJson': '将以 [START] 为开头的所有列表转换为json',
         'qxsckvarandlist.clearList': '清空列表 [LIST]',
@@ -33,6 +35,7 @@ class VarAndList {
         'qxsckvarandlist.replaceOfList': '替换列表 [LIST] 的第 [INDEX] 项为 [VALUE]',
         'qxsckvarandlist.getIndexOfList': '列表 [LIST] 中第一个 [VALUE] 的位置',
         'qxsckvarandlist.getIndexesOfList': '列表 [LIST] 中所有 [VALUE] 的位置',
+        'qxsckvarandlist.newGetIndexesOfList': '列表 [LIST] 中所有 [VALUE] 的位置',
         'qxsckvarandlist.getCountsOfList': '列表 [LIST] 中 [VALUE] 的数量',
         'qxsckvarandlist.listContains': '列表 [LIST] 包括 [VALUE] 吗？',
         'qxsckvarandlist.copyList': '将列表 [LIST1] 复制到列表 [LIST2]',
@@ -53,15 +56,18 @@ class VarAndList {
         'qxsckvarandlist.haveList': 'have list [LIST] ?',
         'qxsckvarandlist.length': 'length of list [LIST]',
         'qxsckvarandlist.getList': 'value of list [LIST]',
+        'qxsckvarandlist.newGetList': 'value of list [LIST]',
+        'qxsckvarandlist.getListRange': 'value of from [LEFT] to [RIGHT] in list [LIST]',
         'qxsckvarandlist.getValueOfList': 'item [INDEX] of list [LIST]',
         'qxsckvarandlist.seriListsToJson': 'convert all lists starting with [START] to json',
         'qxsckvarandlist.clearList': 'delete all of list [LIST]',
         'qxsckvarandlist.deleteOfList': 'delete [INDEX] of list [LIST]',
         'qxsckvarandlist.addValueInList': 'add [VALUE] to list [LIST]',
-        'qxsckvarandlist.addListToList': 'add list [LIST2] to list [LIST]',
+        'qxsckvarandlist.addListInList': 'add list [LIST2] to list [LIST]',
         'qxsckvarandlist.replaceOfList': 'replace item [INDEX] of list [LIST] with [VALUE]',
         'qxsckvarandlist.getIndexOfList': 'first index of list [VALUE] in list [LIST]',
         'qxsckvarandlist.getIndexesOfList': 'indexes of list [LIST] in [VALUE]',
+        'qxsckvarandlist.newGetIndexesOfList': 'indexes of list [LIST] in [VALUE]',
         'qxsckvarandlist.getCountsOfList': 'number of list [LIST] in [VALUE]',
         'qxsckvarandlist.listContains': 'list [LIST] have [VALUE] ?',
         'qxsckvarandlist.copyList': 'copy list [LIST1] to list [LIST2]',
@@ -175,10 +181,41 @@ class VarAndList {
           opcode:'getList',
           blockType: 'reporter',
           text: this.formatMessage('qxsckvarandlist.getList'),
+          hideFromPalette: true,
           arguments: {
             LIST: {
               type: 'string',
               defaultValue:'list'
+            },
+          }
+        },
+        {
+          opcode:'newGetList',
+          blockType: 'reporter',
+          text: this.formatMessage('qxsckvarandlist.newGetList'),
+          arguments: {
+            LIST: {
+              type: 'string',
+              defaultValue:'list'
+            },
+          }
+        },
+        {
+          opcode:'getListRange',
+          blockType: 'reporter',
+          text: this.formatMessage('qxsckvarandlist.getListRange'),
+          arguments: {
+            LIST: {
+              type: 'string',
+              defaultValue:'list'
+            },
+            LEFT: {
+              type: 'string',
+              defaultValue:'1'
+            },
+            RIGHT: {
+              type: 'string',
+              defaultValue:'2'
             },
           }
         },
@@ -302,6 +339,22 @@ class VarAndList {
           opcode:'getIndexesOfList',
           blockType: 'reporter',
           text: this.formatMessage('qxsckvarandlist.getIndexesOfList'),
+          arguments: {
+            LIST: {
+              type: 'string',
+              defaultValue:'list'
+            },
+            VALUE: {
+              type: 'string',
+              defaultValue:'thing'
+            }
+          }
+        },
+        {
+          opcode:'newGetIndexesOfList',
+          blockType: 'reporter',
+          text: this.formatMessage('qxsckvarandlist.newGetIndexesOfList'),
+          hideFromPalette: true,
           arguments: {
             LIST: {
               type: 'string',
@@ -470,11 +523,26 @@ class VarAndList {
   }
   getList(args, util) {
     const variable = util.target.lookupVariableByNameAndType(String(args.LIST), 'list');
-    return variable ? variable.value.toString() :'';
+    return variable ? variable.value.toString() : '';
+  }
+  newGetList(args, util) {
+    const variable = util.target.lookupVariableByNameAndType(String(args.LIST), 'list');
+    return variable ? '['+variable.value.map(value=>'"'+String(value)+'"').join(',')+']' : '[]';
+  }
+  getListRange(args, util) {
+    const variable = util.target.lookupVariableByNameAndType(String(args.LIST), 'list');
+    if (variable) {
+      let length=variable.value.length,left=Number(args.LEFT),right=Number(args.RIGHT);
+      if(left<1) left=1;
+      if(right>length) right=length;
+      left-=1,right-=1;
+      return '['+variable.value.slice(left,right+1).map(value=>'"'+String(value)+'"').join(',')+']';
+    }
+    return '';
   }
   getValueOfList(args, util) {
     const variable = util.target.lookupVariableByNameAndType(String(args.LIST), 'list');
-    if (!variable) return 0;
+    if (!variable) return '';
     const index = ListIndex(args.INDEX, variable.value.length, false);
     if (index === 'INVALID') return '';
     return variable.value[index - 1];
@@ -581,6 +649,24 @@ class VarAndList {
       if (indexes.length > 0) return indexes.toString();
     }
     return '';
+  }
+  newGetIndexesOfList(args, util) {
+    /** @type {VM.ListVariable} */
+    const variable = util.target.lookupVariableByNameAndType(String(args.LIST), 'list');
+    const value = args.VALUE;
+    let flag=openCaseSensitive;
+    if (variable) {
+      var indexes = [];
+      for (var i = 0; i < variable.value.length; i++) {
+        if(!flag){
+          if (Scratch.Cast.compare(variable.value[i], value) === 0) indexes.push(i + 1);
+        }else{
+          if (String(variable.value[i]) === String(value)) indexes.push(i + 1);
+        }
+      }
+      if (indexes.length > 0) return '['+indexes.map(value=>'"'+String(value)+'"').join(',')+']';
+    }
+    return '[]';
   }
   getCountsOfList(args, util) {
     /** @type {VM.ListVariable} */

--- a/qxsck/var-and-list.js
+++ b/qxsck/var-and-list.js
@@ -40,7 +40,7 @@ class VarAndList {
         'qxsckvarandlist.insertOfList': '在列表 [LIST] 的第 [INDEX] 项前插入 [VALUE]',
         'qxsckvarandlist.insertListToList': '在列表 [LIST] 的第 [INDEX] 项前插入列表 [LIST2]',
         'qxsckvarandlist.replaceOfList': '替换列表 [LIST] 的第 [INDEX] 项为 [VALUE]',
-        'qxsckvarandlist.replaceIndexesOfList': '把列表 [LIST] 的第 [LEFT] 到 [RIGHT] 项都替换为 [VALUE]',
+        'qxsckvarandlist.replaceRangeOfList': '把列表 [LIST] 的第 [LEFT] 到 [RIGHT] 项都替换为 [VALUE]',
         'qxsckvarandlist.getIndexOfList': '列表 [LIST] 中第一个 [VALUE] 的位置',
         'qxsckvarandlist.getIndexesOfList': '列表 [LIST] 中所有 [VALUE] 的位置',
         'qxsckvarandlist.newGetIndexesOfList': '列表 [LIST] 中所有 [VALUE] 的位置',
@@ -86,7 +86,7 @@ class VarAndList {
         'qxsckvarandlist.insertOfList': 'insert [VALUE] before [INDEX] item in the list [LIST]',
         'qxsckvarandlist.insertListToList': 'insert list [LIST2] before [INDEX] item in list [LIST]',
         'qxsckvarandlist.replaceOfList': 'replace item [INDEX] of list [LIST] to [VALUE]',
-        'qxsckvarandlist.replaceIndexesOfList': 'replace [LEFT] to [RIGHT] items in list [LIST] with [VALUE]',
+        'qxsckvarandlist.replaceRangeOfList': 'replace [LEFT] to [RIGHT] items in list [LIST] with [VALUE]',
         'qxsckvarandlist.getIndexOfList': 'first index of list [VALUE] in list [LIST]',
         'qxsckvarandlist.getIndexesOfList': 'indexes of list [LIST] in [VALUE]',
         'qxsckvarandlist.newGetIndexesOfList': 'indexes of list [LIST] in [VALUE]',
@@ -403,9 +403,9 @@ class VarAndList {
           }
         },
         {
-          opcode:'replaceIndexesOfList',
+          opcode:'replaceRangeOfList',
           blockType: 'command',
-          text: this.formatMessage('qxsckvarandlist.replaceIndexesOfList'),
+          text: this.formatMessage('qxsckvarandlist.replaceRangeOfList'),
           arguments: {
             LIST: {
               type: 'string',
@@ -870,7 +870,7 @@ class VarAndList {
       }
     }
   }
-  replaceIndexesOfList(args, util) {
+  replaceRangeOfList(args, util) {
     /** @type {VM.ListVariable} */
     const variable = util.target.lookupVariableByNameAndType(String(args.LIST), 'list');
     if (variable) {

--- a/qxsck/var-and-list.js
+++ b/qxsck/var-and-list.js
@@ -109,6 +109,7 @@ class VarAndList {
       color2: '#ed6b00',
       blockIconURI: Icon,
       menuIconURI: Icon,
+      docsURI: 'https://learn.ccw.site/article/647a5fb4-4f01-4b5d-9177-8cf763f68c69',
       blocks: [
         //command,reporter,Boolean,hat,conditional,loop
         {

--- a/qxsck/var-and-list.js
+++ b/qxsck/var-and-list.js
@@ -58,7 +58,7 @@ class VarAndList {
         'qxsckvarandlist.clearList': 'delete all of list [LIST]',
         'qxsckvarandlist.deleteOfList': 'delete [INDEX] of list [LIST]',
         'qxsckvarandlist.addValueInList': 'add [VALUE] to list [LIST]',
-        'qxsckvarandlist.addListInList': 'add list [LIST2] to list [LIST]',
+        'qxsckvarandlist.addListToList': 'add list [LIST2] to list [LIST]',
         'qxsckvarandlist.replaceOfList': 'replace item [INDEX] of list [LIST] with [VALUE]',
         'qxsckvarandlist.getIndexOfList': 'first index of list [VALUE] in list [LIST]',
         'qxsckvarandlist.getIndexesOfList': 'indexes of list [LIST] in [VALUE]',

--- a/qxsck/var-and-list.js
+++ b/qxsck/var-and-list.js
@@ -16,7 +16,7 @@ class VarAndList {
         'qxsckvarandlist.close': '关闭',
 
         'qxsckvarandlist.haveVar': '有变量 [VAR] 吗？',
-        'qxsckvarandlist.getVar': '[VAR] 的值',
+        'qxsckvarandlist.getVar': '变量 [VAR] 的值',
         'qxsckvarandlist.setVar': '将变量 [VAR] 的值设置为 [VALUE]',
         'qxsckvarandlist.seriVarsToJson': '将以 [START] 为开头的所有变量转换为json',
 
@@ -40,6 +40,9 @@ class VarAndList {
         'qxsckvarandlist.listContains': '列表 [LIST] 包括 [VALUE] 吗？',
         'qxsckvarandlist.copyList': '将列表 [LIST1] 复制到列表 [LIST2]',
         'qxsckvarandlist.reverseList': '反转列表 [LIST]',
+
+        'qxsckvarandlist.forEach': '对于从 [LEFT] 到 [RIGHT] 中的每个变量 [VAR]',
+        'qxsckvarandlist.forEachList': '对于列表 [LIST] 中从第 [LEFT] 到第 [RIGHT] 项的每个变量 [VAR]',
       },
       en: {
         'qxsckvarandlist.name': 'var and list',
@@ -47,9 +50,9 @@ class VarAndList {
         'qxsckvarandlist.open': 'open',
         'qxsckvarandlist.close': 'close',
 
-        'qxsckvarandlist.haveVar': 'have [VAR] ?',
-        'qxsckvarandlist.getVar': 'value of [VAR]',
-        'qxsckvarandlist.setVar': 'set the value of [VAR] to [VALUE]',
+        'qxsckvarandlist.haveVar': 'have variable [VAR] ?',
+        'qxsckvarandlist.getVar': 'value of variable [VAR]',
+        'qxsckvarandlist.setVar': 'set the value of variable [VAR] to [VALUE]',
         'qxsckvarandlist.seriVarsToJson': 'convert all variables starting with [START] to json',
 
         'qxsckvarandlist.openCaseSensitive': '[CASE] case sensitive',
@@ -72,6 +75,9 @@ class VarAndList {
         'qxsckvarandlist.listContains': 'list [LIST] have [VALUE] ?',
         'qxsckvarandlist.copyList': 'copy list [LIST1] to list [LIST2]',
         'qxsckvarandlist.reverseList': 'reverse lsit [LIST]',
+
+        'qxsckvarandlist.forEach': 'for each variable [VAR] from [LEFT] to [RIGHT]',
+        'qxsckvarandlist.forEachList': 'for each variable [VAR] in value of from [LEFT] to [RIGHT] in list [LIST]',
       },
     });
   }
@@ -92,7 +98,7 @@ class VarAndList {
       blockIconURI: Icon,
       menuIconURI: Icon,
       blocks: [
-        //command,reporter,Boolean,hat
+        //command,reporter,Boolean,hat,conditional,loop
         {
           opcode:'haveVar',
           blockType: 'Boolean',
@@ -339,6 +345,7 @@ class VarAndList {
           opcode:'getIndexesOfList',
           blockType: 'reporter',
           text: this.formatMessage('qxsckvarandlist.getIndexesOfList'),
+          hideFromPalette: true,
           arguments: {
             LIST: {
               type: 'string',
@@ -354,7 +361,6 @@ class VarAndList {
           opcode:'newGetIndexesOfList',
           blockType: 'reporter',
           text: this.formatMessage('qxsckvarandlist.newGetIndexesOfList'),
-          hideFromPalette: true,
           arguments: {
             LIST: {
               type: 'string',
@@ -419,6 +425,49 @@ class VarAndList {
             LIST: {
               type: 'string',
               defaultValue:'list'
+            },
+          }
+        },
+
+        {
+          opcode:'forEach',
+          blockType: 'conditional',
+          text: this.formatMessage('qxsckvarandlist.forEach'),
+          arguments: {
+            VAR: {
+              type: 'string',
+              defaultValue:'variable'
+            },
+            LEFT: {
+              type: 'string',
+              defaultValue:'1'
+            },
+            RIGHT: {
+              type: 'string',
+              defaultValue:'5'
+            },
+          }
+        },
+        {
+          opcode:'forEachList',
+          blockType: 'conditional',
+          text: this.formatMessage('qxsckvarandlist.forEachList'),
+          arguments: {
+            VAR: {
+              type: 'string',
+              defaultValue:'variable'
+            },
+            LIST: {
+              type: 'string',
+              defaultValue:'list'
+            },
+            LEFT: {
+              type: 'string',
+              defaultValue:'1'
+            },
+            RIGHT: {
+              type: 'string',
+              defaultValue:'5'
             },
           }
         },
@@ -543,9 +592,11 @@ class VarAndList {
   getValueOfList(args, util) {
     const variable = util.target.lookupVariableByNameAndType(String(args.LIST), 'list');
     if (!variable) return '';
-    const index = ListIndex(args.INDEX, variable.value.length, false);
-    if (index === 'INVALID') return '';
-    return variable.value[index - 1];
+    const index = String(args.INDEX);
+    if(Number(index)<=variable.value.length && Number(index)>=1){
+      return variable.value[index - 1];
+    }
+    return '';
   }
   seriListsToJson(args, util) {
     const start = String(args.START);
@@ -573,11 +624,12 @@ class VarAndList {
     /** @type {VM.ListVariable} */
     const variable = util.target.lookupVariableByNameAndType(String(args.LIST), 'list');
     if (variable) {
-      const index = ListIndex(args.INDEX, variable.value.length, true);
+      const index = String(args.INDEX);
       if (index === 'ALL') {
         variable.value = [];
-      } else if (index !== 'INVALID') {
-        variable.value.splice(index - 1, 1);
+      } else if(Number(index)<=variable.value.length && Number(index)>=1){
+
+        variable.value.splice(Number(index) - 1, 1);
         variable._monitorUpToDate = false;
       }
     }
@@ -609,8 +661,8 @@ class VarAndList {
     /** @type {VM.ListVariable} */
     const variable = util.target.lookupVariableByNameAndType(String(args.LIST), 'list');
     if (variable) {
-      const index = ListIndex(args.INDEX, variable.value.length, false);
-      if (index !== 'INVALID') {
+      const index = String(args.INDEX);
+      if(Number(index)<=variable.value.length && Number(index)>=1){
         variable.value[index - 1] = args.VALUE;
         variable._monitorUpToDate = false;
       }
@@ -709,6 +761,7 @@ class VarAndList {
     const list2 = util.target.lookupVariableByNameAndType(String(args.LIST2), 'list');
     if (list1 && list2) {
       list2.value = list1.value.slice();
+      list2._monitorUpToDate = false;
     }
   }
   reverseList(args, util) {
@@ -719,6 +772,41 @@ class VarAndList {
       list.reverse();
       variable.value=list;
       variable._monitorUpToDate = false;
+    }
+  }
+
+  forEach(args,util){
+    const variable = util.target.lookupVariableByNameAndType(String(args.VAR), '');
+    if (variable) {
+      let left=Number(args.LEFT),right=Number(args.RIGHT);
+      let range=right-left+1;
+      if(typeof util.stackFrame.index==='undefined'){
+        util.stackFrame.index = 0;
+      }
+
+      if(util.stackFrame.index<range){
+          util.stackFrame.index++;
+          variable.value=util.stackFrame.index+left-1;
+          util.startBranch(1,true);
+      }
+    }
+  }
+  forEachList(args,util){
+    const variable = util.target.lookupVariableByNameAndType(String(args.VAR), '');
+    const list = util.target.lookupVariableByNameAndType(String(args.LIST), 'list');
+    if (variable && list) {
+      let left=Number(args.LEFT)>0?Number(args.LEFT):1,
+          right=Number(args.RIGHT)<=list.value.length?Number(args.RIGHT):list.value.length;
+      let range=right-left+1;
+      if(typeof util.stackFrame.index==='undefined'){
+        util.stackFrame.index = 0;
+      }
+
+      if(util.stackFrame.index<range){
+          util.stackFrame.index++;
+          variable.value=list.value[util.stackFrame.index+left-2];
+          util.startBranch(1,true);
+      }
     }
   }
 }

--- a/qxsck/var-and-list.js
+++ b/qxsck/var-and-list.js
@@ -21,7 +21,7 @@ class VarAndList {
 
         'qxsckvarandlist.haveVar': '有变量 [VAR] 吗？',
         'qxsckvarandlist.getVar': '变量 [VAR] 的值',
-        'qxsckvarandlist.setVar': '将变量 [VAR] 的值设置为 [VALUE]',
+        'qxsckvarandlist.setVar': '设置变量 [VAR] 的值为 [VALUE]',
         'qxsckvarandlist.seriVarsToJson': '将以 [START] 为开头的所有变量转换为json',
 
         'qxsckvarandlist.openCaseSensitive': '[CASE] 大小写敏感',
@@ -33,10 +33,14 @@ class VarAndList {
         'qxsckvarandlist.getValueOfList': '列表 [LIST] 的第 [INDEX] 项',
         'qxsckvarandlist.seriListsToJson': '将以 [START] 为开头的所有列表转换为json',
         'qxsckvarandlist.clearList': '清空列表 [LIST]',
+        'qxsckvarandlist.setList': '设置列表 [LIST] 的内容为列表 [LIST2]',
         'qxsckvarandlist.deleteOfList': '删除列表 [LIST] 的第 [INDEX] 项',
         'qxsckvarandlist.addValueInList': '在列表 [LIST] 末尾添加 [VALUE]',
         'qxsckvarandlist.addListToList': '在列表 [LIST] 末尾添加列表 [LIST2]',
+        'qxsckvarandlist.insertOfList': '在列表 [LIST] 的第 [INDEX] 项前插入 [VALUE]',
+        'qxsckvarandlist.insertListToList': '在列表 [LIST] 的第 [INDEX] 项前插入列表 [LIST2]',
         'qxsckvarandlist.replaceOfList': '替换列表 [LIST] 的第 [INDEX] 项为 [VALUE]',
+        'qxsckvarandlist.replaceIndexesOfList': '把列表 [LIST] 的第 [LEFT] 到 [RIGHT] 项都替换为 [VALUE]',
         'qxsckvarandlist.getIndexOfList': '列表 [LIST] 中第一个 [VALUE] 的位置',
         'qxsckvarandlist.getIndexesOfList': '列表 [LIST] 中所有 [VALUE] 的位置',
         'qxsckvarandlist.newGetIndexesOfList': '列表 [LIST] 中所有 [VALUE] 的位置',
@@ -46,11 +50,10 @@ class VarAndList {
         'qxsckvarandlist.reverseList': '反转列表 [LIST]',
         'qxsckvarandlist.sortList': '以 [CASE] 排序列表 [LIST]',
         'qxsckvarandlist.sortListRange': '以 [CASE] 排序列表 [LIST] 的第 [LEFT] 到 [RIGHT] 项',
+        'qxsckvarandlist.mapObject': '映射对象 [OBJ] 的值到列表 [LIST] ，键到列表 [LIST2]',
 
-        'qxsckvarandlist.unSupportCompile': '⚠️不支持编译',
-        
-        'qxsckvarandlist.forEach': '⚠️对于从 [LEFT] 到 [RIGHT] 中的每个变量 [VAR]',
-        'qxsckvarandlist.forEachList': '⚠️对于列表 [LIST] 中从第 [LEFT] 到第 [RIGHT] 项的每个变量 [VAR]',
+        'qxsckvarandlist.forEach': '对于从 [LEFT] 到 [RIGHT] 中的每个变量 [VAR]',
+        'qxsckvarandlist.forEachList': '对于列表 [LIST] 中从第 [LEFT] 到第 [RIGHT] 项的每个变量 [VAR]',
       },
       en: {
         'qxsckvarandlist.name': 'variable and list',
@@ -64,7 +67,7 @@ class VarAndList {
 
         'qxsckvarandlist.haveVar': 'have variable [VAR] ?',
         'qxsckvarandlist.getVar': 'value of variable [VAR]',
-        'qxsckvarandlist.setVar': 'set the value of variable [VAR] to [VALUE]',
+        'qxsckvarandlist.setVar': 'set variable [VAR] to [VALUE]',
         'qxsckvarandlist.seriVarsToJson': 'convert all variables starting with [START] to json',
 
         'qxsckvarandlist.openCaseSensitive': '[CASE] case sensitive',
@@ -76,10 +79,14 @@ class VarAndList {
         'qxsckvarandlist.getValueOfList': 'item [INDEX] of list [LIST]',
         'qxsckvarandlist.seriListsToJson': 'convert all lists starting with [START] to json',
         'qxsckvarandlist.clearList': 'delete all of list [LIST]',
+        'qxsckvarandlist.setList': 'set [LIST] to list [LIST2]',
         'qxsckvarandlist.deleteOfList': 'delete [INDEX] of list [LIST]',
         'qxsckvarandlist.addValueInList': 'add [VALUE] to list [LIST]',
         'qxsckvarandlist.addListInList': 'add list [LIST2] to list [LIST]',
-        'qxsckvarandlist.replaceOfList': 'replace item [INDEX] of list [LIST] with [VALUE]',
+        'qxsckvarandlist.insertOfList': 'insert [VALUE] before [INDEX] item in the list [LIST]',
+        'qxsckvarandlist.insertListToList': 'insert list [LIST2] before [INDEX] item in list [LIST]',
+        'qxsckvarandlist.replaceOfList': 'replace item [INDEX] of list [LIST] to [VALUE]',
+        'qxsckvarandlist.replaceIndexesOfList': 'replace [LEFT] to [RIGHT] items in list [LIST] with [VALUE]',
         'qxsckvarandlist.getIndexOfList': 'first index of list [VALUE] in list [LIST]',
         'qxsckvarandlist.getIndexesOfList': 'indexes of list [LIST] in [VALUE]',
         'qxsckvarandlist.newGetIndexesOfList': 'indexes of list [LIST] in [VALUE]',
@@ -89,11 +96,10 @@ class VarAndList {
         'qxsckvarandlist.reverseList': 'reverse lsit [LIST]',
         'qxsckvarandlist.sortList': 'sort list [LIST] with [CASE]',
         'qxsckvarandlist.sortListRange': 'sort from [LEFT] to [RIGHT] in list [LIST] with [CASE]',
+        'qxsckvarandlist.mapObject': 'map object [OBJ] to list [LIST],key to list [LIST2]',
 
-        'qxsckvarandlist.unSupportCompile': '⚠️unsupport complie',
-        
-        'qxsckvarandlist.forEach': '⚠️for each variable [VAR] from [LEFT] to [RIGHT]',
-        'qxsckvarandlist.forEachList': '⚠️for each variable [VAR] in value of from [LEFT] to [RIGHT] in list [LIST]',
+        'qxsckvarandlist.forEach': 'for each variable [VAR] from [LEFT] to [RIGHT]',
+        'qxsckvarandlist.forEachList': 'for each variable [VAR] in value of from [LEFT] to [RIGHT] in list [LIST]',
       },
     });
   }
@@ -280,6 +286,21 @@ class VarAndList {
           }
         },
         {
+          opcode:'setList',
+          blockType: 'command',
+          text: this.formatMessage('qxsckvarandlist.setList'),
+          arguments: {
+            LIST: {
+              type: 'string',
+              defaultValue:'list'
+            },
+            LIST2: {
+              type: 'string',
+              defaultValue:'["a","a"]'
+            },
+          }
+        },
+        {
           opcode:'deleteOfList',
           blockType: 'command',
           text: this.formatMessage('qxsckvarandlist.deleteOfList'),
@@ -325,6 +346,44 @@ class VarAndList {
           }
         },
         {
+          opcode:'insertOfList',
+          blockType: 'command',
+          text: this.formatMessage('qxsckvarandlist.insertOfList'),
+          arguments: {
+            LIST: {
+              type: 'string',
+              defaultValue:'list'
+            },
+            INDEX: {
+              type: 'string',
+              defaultValue:'1'
+            },
+            VALUE: {
+              type: 'string',
+              defaultValue:'thing'
+            }
+          }
+        },
+        {
+          opcode:'insertListToList',
+          blockType: 'command',
+          text: this.formatMessage('qxsckvarandlist.insertListToList'),
+          arguments: {
+            LIST: {
+              type: 'string',
+              defaultValue:'list'
+            },
+            INDEX: {
+              type: 'string',
+              defaultValue:'1'
+            },
+            LIST2: {
+              type: 'string',
+              defaultValue:'["ark","os"]'
+            }
+          }
+        },
+        {
           opcode:'replaceOfList',
           blockType: 'command',
           text: this.formatMessage('qxsckvarandlist.replaceOfList'),
@@ -336,6 +395,29 @@ class VarAndList {
             INDEX: {
               type: 'string',
               defaultValue:'1'
+            },
+            VALUE: {
+              type: 'string',
+              defaultValue:'thing'
+            }
+          }
+        },
+        {
+          opcode:'replaceIndexesOfList',
+          blockType: 'command',
+          text: this.formatMessage('qxsckvarandlist.replaceIndexesOfList'),
+          arguments: {
+            LIST: {
+              type: 'string',
+              defaultValue:'list'
+            },
+            LEFT: {
+              type: 'string',
+              defaultValue:'1'
+            },
+            RIGHT: {
+              type: 'string',
+              defaultValue:'2'
             },
             VALUE: {
               type: 'string',
@@ -483,9 +565,28 @@ class VarAndList {
             },
           }
         },
+        {
+          opcode:'mapObject',
+          blockType: 'command',
+          text: this.formatMessage('qxsckvarandlist.mapObject'),
+          arguments: {
+            OBJ: {
+              type: 'string',
+              defaultValue:'{"name":"Gandi"}'
+            },
+            LIST: {
+              type: 'string',
+              defaultValue:'list'
+            },
+            LIST2: {
+              type: 'string',
+              defaultValue:'list2'
+            },
+          }
+        },
 
-        '---'+this.formatMessage('qxsckvarandlist.unSupportCompile'),
-        
+        '---',
+
         {
           opcode:'forEach',
           blockType: 'conditional',
@@ -689,6 +790,20 @@ class VarAndList {
     const variable = util.target.lookupVariableByNameAndType(String(args.LIST), 'list');
     if (variable) {
       variable.value = [];
+      variable._monitorUpToDate = false;
+    }
+  }
+  setList(args, util) {
+    /** @type {VM.ListVariable} */
+    const variable = util.target.lookupVariableByNameAndType(String(args.LIST), 'list');
+    if (variable) {
+      try{
+        let arr=JSON.parse(args.LIST2);
+        variable.value=arr;
+        variable._monitorUpToDate = false;
+      }catch(error){
+        console.log('error:', error);
+      }
     }
   }
   deleteOfList(args, util) {
@@ -715,17 +830,33 @@ class VarAndList {
   }
   addListToList(args, util) {
     /** @type {VM.ListVariable} */
-    const variable = util.target.lookupVariableByNameAndType(String(args.LIST), 'list'),list2=String(args.LIST2);
+    const variable = util.target.lookupVariableByNameAndType(String(args.LIST), 'list');
     if (variable) {
-      try {
-        let arr = JSON.parse(list2);
-        for (let i = 0; i < arr.length; i++) {
-          variable.value.push(arr[i]);
-        }
+      try{
+        let arr=JSON.parse(args.LIST2);
+        for(let i=0;i<arr.length;i++) variable.value.push(arr[i]);
         variable._monitorUpToDate = false;
-      } catch (error) {
+      }catch(error){
         console.log('error:', error);
       }
+    }
+  }
+  insertOfList(args,util){
+    const variable = util.target.lookupVariableByNameAndType(String(args.LIST), 'list');
+    const value=args.VALUE;
+    const index=Number(args.INDEX)>variable.value.length?variable.value.length+1:Number(args.INDEX);
+    variable.value.splice(index-1,0,value);
+    variable._monitorUpToDate = false;
+  }
+  insertListToList(args,util){
+    const variable = util.target.lookupVariableByNameAndType(String(args.LIST), 'list');
+    const index=Number(args.INDEX)>variable.value.length?variable.value.length+1:Number(args.INDEX);
+    try{
+      let arr=JSON.parse(args.LIST2);
+      variable.value.splice(index-1,0,...arr);
+    variable._monitorUpToDate = false;
+    }catch(error){
+      console.log('error:', error);
     }
   }
   replaceOfList(args, util) {
@@ -737,6 +868,20 @@ class VarAndList {
         variable.value[index - 1] = args.VALUE;
         variable._monitorUpToDate = false;
       }
+    }
+  }
+  replaceIndexesOfList(args, util) {
+    /** @type {VM.ListVariable} */
+    const variable = util.target.lookupVariableByNameAndType(String(args.LIST), 'list');
+    if (variable) {
+      let length=variable.value.length,left=Number(args.LEFT),right=Number(args.RIGHT);
+      if(left<1) left=1;
+      if(right>length) right=length;
+      left-=1,right-=1;
+      for(let i=left;i<=right;i++){
+        variable.value[i]=args.VALUE;
+      }
+      variable._monitorUpToDate = false;
     }
   }
   getIndexOfList(args, util) {
@@ -889,6 +1034,25 @@ class VarAndList {
       let list2=variable.value.slice();
       variable.value=[...list2.slice(0,left),...list,...list2.slice(right+1,length)];
       variable._monitorUpToDate = false;
+    }
+  }
+  mapObject(args,util){
+    const list = util.target.lookupVariableByNameAndType(String(args.LIST), 'list'),
+          list2 = util.target.lookupVariableByNameAndType(String(args.LIST2), 'list');
+    if (list && list2) {
+      try{
+        let object=JSON.parse(args.OBJ);
+        list.value=[];
+        list2.value=[];
+        for(let key in object){
+          list.value.push(key);
+          list2.value.push(object[key]);
+        }
+        list._monitorUpToDate = false;
+        list2._monitorUpToDate = false;
+      }catch(error){
+        console.log('error:', error);
+      }
     }
   }
 

--- a/qxsck/var-and-list.js
+++ b/qxsck/var-and-list.js
@@ -47,8 +47,10 @@ class VarAndList {
         'qxsckvarandlist.sortList': '以 [CASE] 排序列表 [LIST]',
         'qxsckvarandlist.sortListRange': '以 [CASE] 排序列表 [LIST] 的第 [LEFT] 到 [RIGHT] 项',
 
-        'qxsckvarandlist.forEach': '对于从 [LEFT] 到 [RIGHT] 中的每个变量 [VAR]',
-        'qxsckvarandlist.forEachList': '对于列表 [LIST] 中从第 [LEFT] 到第 [RIGHT] 项的每个变量 [VAR]',
+        'qxsckvarandlist.unSupportCompile': '⚠️不支持编译',
+        
+        'qxsckvarandlist.forEach': '⚠️对于从 [LEFT] 到 [RIGHT] 中的每个变量 [VAR]',
+        'qxsckvarandlist.forEachList': '⚠️对于列表 [LIST] 中从第 [LEFT] 到第 [RIGHT] 项的每个变量 [VAR]',
       },
       en: {
         'qxsckvarandlist.name': 'variable and list',
@@ -88,8 +90,10 @@ class VarAndList {
         'qxsckvarandlist.sortList': 'sort list [LIST] with [CASE]',
         'qxsckvarandlist.sortListRange': 'sort from [LEFT] to [RIGHT] in list [LIST] with [CASE]',
 
-        'qxsckvarandlist.forEach': 'for each variable [VAR] from [LEFT] to [RIGHT]',
-        'qxsckvarandlist.forEachList': 'for each variable [VAR] in value of from [LEFT] to [RIGHT] in list [LIST]',
+        'qxsckvarandlist.unSupportCompile': '⚠️unsupport complied',
+        
+        'qxsckvarandlist.forEach': '⚠️for each variable [VAR] from [LEFT] to [RIGHT]',
+        'qxsckvarandlist.forEachList': '⚠️for each variable [VAR] in value of from [LEFT] to [RIGHT] in list [LIST]',
       },
     });
   }
@@ -480,7 +484,7 @@ class VarAndList {
           }
         },
 
-        '---',
+        '---'+this.formatMessage('qxsckvarandlist.unSupportCompile'),
         
         {
           opcode:'forEach',

--- a/qxsck/var-and-list.js
+++ b/qxsck/var-and-list.js
@@ -1,0 +1,662 @@
+/*Icon积木/菜单/小图标*/
+const Icon="data:image/svg+xml;base64,PHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHdpZHRoPSI3OS45ODQzOSIgaGVpZ2h0PSI3OS45ODQzOSIgdmlld0JveD0iMCwwLDc5Ljk4NDM5LDc5Ljk4NDM5Ij48ZyB0cmFuc2Zvcm09InRyYW5zbGF0ZSgtMjA5LjU2NDk1LC0xNDcuOTY0OTUpIj48ZyBkYXRhLXBhcGVyLWRhdGE9InsmcXVvdDtpc1BhaW50aW5nTGF5ZXImcXVvdDs6dHJ1ZX0iIGZpbGwtcnVsZT0ibm9uemVybyIgc3Ryb2tlLWxpbmVqb2luPSJtaXRlciIgc3Ryb2tlLW1pdGVybGltaXQ9IjEwIiBzdHJva2UtZGFzaGFycmF5PSIiIHN0cm9rZS1kYXNob2Zmc2V0PSIwIiBzdHlsZT0ibWl4LWJsZW5kLW1vZGU6IG5vcm1hbCI+PGc+PHBhdGggZD0iTTIzNy40NDIwNywxOTkuMzk1NTdjMCwtMTMuMDA4MTMgMTAuNTQ1MTEsLTIzLjU1Mzc3IDIzLjU1MzUsLTIzLjU1Mzc3YzEzLjAwODEzLDAgMjMuNTUzNzcsMTAuNTQ1NjQgMjMuNTUzNzcsMjMuNTUzNzdjMCwxMy4wMDgxMyAtMTAuNTQ1NjQsMjMuNTUzNzcgLTIzLjU1Mzc3LDIzLjU1Mzc3Yy0xMy4wMDg0MSwwIC0yMy41NTM3NywtMTAuNTQ1NjUgLTIzLjU1Mzc3LC0yMy41NTM3N3oiIGZpbGw9Im5vbmUiIHN0cm9rZS1vcGFjaXR5PSIwLjE1IiBzdHJva2U9IiMwMDAwMDAiIHN0cm9rZS13aWR0aD0iMTAiIHN0cm9rZS1saW5lY2FwPSJidXR0Ii8+PHBhdGggZD0iTTIzNy42NDIwNywxOTkuNTk1NTdjMCwtMTMuMDA4MTMgMTAuNTQ1MTEsLTIzLjU1Mzc3IDIzLjU1MzUsLTIzLjU1Mzc3YzEzLjAwODEzLDAgMjMuNTUzNzcsMTAuNTQ1NjQgMjMuNTUzNzcsMjMuNTUzNzdjMCwxMy4wMDgxMyAtMTAuNTQ1NjQsMjMuNTUzNzcgLTIzLjU1Mzc3LDIzLjU1Mzc3Yy0xMy4wMDg0MSwwIC0yMy41NTM3NywtMTAuNTQ1NjUgLTIzLjU1Mzc3LC0yMy41NTM3N3oiIGZpbGw9IiNmZjhjMTkiIHN0cm9rZT0iI2RiNmUwMCIgc3Ryb2tlLXdpZHRoPSI0IiBzdHJva2UtbGluZWNhcD0iYnV0dCIvPjxnIGZpbGw9Im5vbmUiIHN0cm9rZT0iI2ZmZmZmZiIgc3Ryb2tlLXdpZHRoPSI1IiBzdHJva2UtbGluZWNhcD0icm91bmQiPjxwYXRoIGQ9Ik0yNjQuMzU1NDMsMjA1LjY0MDgzbC02LjcyNTM5LC0xMS4zOTQ3OCIvPjxwYXRoIGQ9Ik0yNTUuMjY0MjUsMjA1LjA0OTE4bDExLjY1MzksLTEwLjgwMzEzIiBkYXRhLXBhcGVyLWRhdGE9InsmcXVvdDtpbmRleCZxdW90OzpudWxsfSIvPjwvZz48cGF0aCBkPSJNMjcyLjAwNzE5LDE4Ni41NjAwNWMwLDAgNC42NzA1LDUuNDc1NTIgNC42MDIwMSwxMy4xMTQ2OGMtMC4wODIxOCw5LjE2Mjk0IC01LjM3OTkzLDEzLjMyMzk1IC01LjM3OTkzLDEzLjMyMzk1IiBkYXRhLXBhcGVyLWRhdGE9InsmcXVvdDtpbmRleCZxdW90OzpudWxsfSIgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjZmZmZmZmIiBzdHJva2Utd2lkdGg9IjUiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIvPjxwYXRoIGQ9Ik0yNTAuODg2NjcsMjEyLjU3OTJjMCwwIC01LjI1MDU2LC00LjYxMTE2IC00Ljc3NTM2LC0xNC4xMzY3OWMwLjM5NjI0LC03Ljk0MTU0IDUuNTg0OTMsLTEzLjM3Nzk1IDUuNTg0OTMsLTEzLjM3Nzk1IiBmaWxsPSJub25lIiBzdHJva2U9IiNmZmZmZmYiIHN0cm9rZS13aWR0aD0iNSIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIi8+PC9nPjxnPjxwYXRoIGQ9Ik0yMTQuNTY1MjMsMTc2LjUxODcyYzAsLTEzLjAwODEzIDEwLjU0NTEsLTIzLjU1Mzc3IDIzLjU1Mzc3LC0yMy41NTM3N2MxMy4wMDgxMywwIDIzLjU1MzUsMTAuNTQ1NjUgMjMuNTUzNSwyMy41NTM3N2MwLDEzLjAwODEzIC0xMC41NDU2NSwyMy41NTM3OCAtMjMuNTUzNzcsMjMuNTUzNzhjLTEzLjAwODEzLDAgLTIzLjU1Mzc3LC0xMC41NDU2NSAtMjMuNTUzNzcsLTIzLjU1Mzc3eiIgZmlsbD0ibm9uZSIgc3Ryb2tlLW9wYWNpdHk9IjAuMTUiIHN0cm9rZT0iIzAwMDAwMCIgc3Ryb2tlLXdpZHRoPSIxMCIgc3Ryb2tlLWxpbmVjYXA9ImJ1dHQiLz48cGF0aCBkPSJNMjE0LjU2NTIzLDE3Ni41MTg3MmMwLC0xMy4wMDgxMyAxMC41NDUxLC0yMy41NTM3NyAyMy41NTM3NywtMjMuNTUzNzdjMTMuMDA4MTMsMCAyMy41NTM1LDEwLjU0NTY1IDIzLjU1MzUsMjMuNTUzNzdjMCwxMy4wMDgxMyAtMTAuNTQ1NjUsMjMuNTUzNzggLTIzLjU1Mzc3LDIzLjU1Mzc4Yy0xMy4wMDgxMywwIC0yMy41NTM3NywtMTAuNTQ1NjUgLTIzLjU1Mzc3LC0yMy41NTM3N3oiIGZpbGw9IiNmZjY2MWEiIHN0cm9rZT0iI2U2NGQwMCIgc3Ryb2tlLXdpZHRoPSI1IiBzdHJva2UtbGluZWNhcD0iYnV0dCIvPjxwYXRoIGQ9Ik0yNTEuMDA0NDEsMTc2LjMxMzE4aC0xNS4wNzQ2NE0yNTEuMDA0NDEsMTY1LjkxNjk3aC0xNS4wNzQ2NE0yMjUuNzA2ODgsMTY2LjA5MDI5aDAuNjkzMjZNMjI2LjQwMDE1LDE3Ni40ODY1aC0wLjY5MzI2TTIzNS45Mjk3NywxODYuNzA5MzhoMTUuMDc0NjRNMjI2LjQwMDE1LDE4Ni44ODI3aC0wLjY5MzI2IiBmaWxsPSJub25lIiBzdHJva2U9IiNmZmZmZmYiIHN0cm9rZS13aWR0aD0iNSIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIi8+PC9nPjxnIGZpbGw9Im5vbmUiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCI+PHBhdGggZD0iTTI1OC4zNTU2NCwxNjkuMzY5MzNoMjQuMjAyMzlNMjcwLjQ1Njg0LDE1Ny4yNjg3djI0LjIwMTg0IiBzdHJva2Utb3BhY2l0eT0iMC4xNSIgc3Ryb2tlPSIjMDAwMDAwIiBzdHJva2Utd2lkdGg9IjEwIi8+PHBhdGggZD0iTTI1OC4zNTU2NCwxNjkuMzY5MzNoMjQuMjAyMzlNMjcwLjQ1Njg0LDE1Ny4yNjg3djI0LjIwMTg0IiBzdHJva2U9IiNmZmZmZmYiIHN0cm9rZS13aWR0aD0iNSIvPjwvZz48L2c+PC9nPjwvc3ZnPjwhLS1yb3RhdGlvbkNlbnRlcjozMC40MzUwNTAwMDAwMDAxMDM6MzIuMDM1MDUwMDAwMDAwMDEtLT4=";
+/*insetIcon大图标*/
+const insetIcon="data:image/svg+xml;base64,PHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHdpZHRoPSI1OTkuNjU3NDgiIGhlaWdodD0iMzcxLjUxOTUyIiB2aWV3Qm94PSIwLDAsNTk5LjY1NzQ4LDM3MS41MTk1MiI+PGcgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoNTkuODI4NzQsNS43NTk3NikiPjxnIGRhdGEtcGFwZXItZGF0YT0ieyZxdW90O2lzUGFpbnRpbmdMYXllciZxdW90Ozp0cnVlfSIgZmlsbC1ydWxlPSJub256ZXJvIiBzdHJva2UtbGluZWpvaW49Im1pdGVyIiBzdHJva2UtbWl0ZXJsaW1pdD0iMTAiIHN0cm9rZS1kYXNoYXJyYXk9IiIgc3Ryb2tlLWRhc2hvZmZzZXQ9IjAiIHN0eWxlPSJtaXgtYmxlbmQtbW9kZTogbm9ybWFsIj48cGF0aCBkPSJNLTU5LjgyODc0LDM2NS43NTk3NnYtMzcxLjUxOTUyaDU5OS42NTc0OHYzNzEuNTE5NTJ6IiBmaWxsPSIjMGZiZDhjIiBzdHJva2U9Im5vbmUiIHN0cm9rZS13aWR0aD0iMSIgc3Ryb2tlLWxpbmVjYXA9ImJ1dHQiLz48Zz48cGF0aCBkPSJNLTI1LjAxNjQzLDE4MGMwLC00OS40MjI5NiA0MC4wNjQ5NiwtODkuNDkgODkuNDg4OTYsLTg5LjQ5YzQ5LjQyMjk2LDAgODkuNDksNDAuMDY3MDQgODkuNDksODkuNDljMCw0OS40MjI5NiAtNDAuMDY3MDQsODkuNDkgLTg5LjQ5LDg5LjQ5Yy00OS40MjQsMCAtODkuNDksLTQwLjA2NzA0IC04OS40OSwtODkuNDl6TTMyNi4wMzg1MSwxODBjMCwtNDkuNDIyOTYgNDAuMDY0OTYsLTg5LjQ5IDg5LjQ5LC04OS40OWM0OS40MjI5NiwwIDg5LjQ4ODk2LDQwLjA2NzA0IDg5LjQ4ODk2LDg5LjQ5YzAsNDkuNDIyOTYgLTQwLjA2NzA0LDg5LjQ5IC04OS40OSw4OS40OWMtNDkuNDIyOTYsMCAtODkuNDksLTQwLjA2NzA0IC04OS40OSwtODkuNDl6IiBmaWxsPSJub25lIiBzdHJva2Utb3BhY2l0eT0iMC4xNSIgc3Ryb2tlPSIjMDAwMDAwIiBzdHJva2Utd2lkdGg9IjI1IiBzdHJva2UtbGluZWNhcD0iYnV0dCIvPjxwYXRoIGQ9Ik0tMjUuMDE2NDMsMTgwYzAsLTQ5LjQyMjk2IDQwLjA2NDk2LC04OS40OSA4OS40ODg5NiwtODkuNDljNDkuNDIyOTYsMCA4OS40OSw0MC4wNjcwNCA4OS40OSw4OS40OWMwLDQ5LjQyMjk2IC00MC4wNjcwNCw4OS40OSAtODkuNDksODkuNDljLTQ5LjQyNCwwIC04OS40OSwtNDAuMDY3MDQgLTg5LjQ5LC04OS40OXoiIGZpbGw9IiNmZjhjMTkiIHN0cm9rZT0iI2RiNmUwMCIgc3Ryb2tlLXdpZHRoPSIxMCIgc3Ryb2tlLWxpbmVjYXA9ImJ1dHQiLz48ZyBmaWxsPSJub25lIiBzdHJva2U9IiNmZmZmZmYiIHN0cm9rZS13aWR0aD0iMjAiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCI+PHBhdGggZD0iTTc2LjQ3ODA4LDIwMi45NjgzbC0yNS41NTIzNywtNDMuMjkzMjIiLz48cGF0aCBkPSJNODYuMjE0ODgsMTU5LjY3NTA4bC00NC4yNzc3Miw0MS4wNDUzIiBkYXRhLXBhcGVyLWRhdGE9InsmcXVvdDtpbmRleCZxdW90OzpudWxsfSIvPjwvZz48cGF0aCBkPSJNMzI2LjAzODUxLDE4MGMwLC00OS40MjI5NiA0MC4wNjQ5NiwtODkuNDkgODkuNDksLTg5LjQ5YzQ5LjQyMjk2LDAgODkuNDg4OTYsNDAuMDY3MDQgODkuNDg4OTYsODkuNDljMCw0OS40MjI5NiAtNDAuMDY3MDQsODkuNDkgLTg5LjQ5LDg5LjQ5Yy00OS40MjI5NiwwIC04OS40OSwtNDAuMDY3MDQgLTg5LjQ5LC04OS40OXoiIGZpbGw9IiNmZjY2MWEiIHN0cm9rZT0iI2U2NGQwMCIgc3Ryb2tlLXdpZHRoPSIxMCIgc3Ryb2tlLWxpbmVjYXA9ImJ1dHQiLz48ZyBmaWxsPSJub25lIiBzdHJva2UtbGluZWNhcD0icm91bmQiPjxwYXRoIGQ9Ik00NTkuODk0NywyNDYuOTI3NTdoNDUuMTIyNzdNNDgyLjQ1NjA4LDIyNC4zNjcyM3Y0NS4xMjE3MyIgc3Ryb2tlLW9wYWNpdHk9IjAuMTUiIHN0cm9rZT0iIzAwMDAwMCIgc3Ryb2tlLXdpZHRoPSI0NSIvPjxwYXRoIGQ9Ik00NTkuODk0NywyNDYuOTI3NTdoNDUuMTIyNzdNNDgyLjQ1NjA4LDIyNC4zNjcyM3Y0NS4xMjE3MyIgc3Ryb2tlPSIjZmZmZmZmIiBzdHJva2Utd2lkdGg9IjI1Ii8+PC9nPjxwYXRoIGQ9Ik00MDYuNjcxMDksMTc5LjY4MzYzaDU1LjAzNDQyTTQwNi42NzEwOSwxNDEuNzI5MjFoNTUuMDM0NDJNMzcxLjg4MDQxLDE0Mi4zNjE5NmgtMi41MzA5OU0zNjkuMzQ5NDIsMTgwLjMxNjM3aDIuNTMwOTlNNDYxLjcwNTUyLDIxNy42MzgwNGgtNTUuMDM0NDJNMzY5LjM0OTQyLDIxOC4yNzA3OWgyLjUzMDk5TTIyLjcwMTg2LDIyOS41MjcwM2MwLDAgLTE5LjE2ODcsLTE2LjgzNDQgLTE3LjQzMzg1LC01MS42MTA1MWMxLjQ0NjU4LC0yOC45OTI5MyAyMC4zODk0NCwtNDguODQwMTYgMjAuMzg5NDQsLTQ4Ljg0MDE2IiBmaWxsPSJub25lIiBzdHJva2U9IiNmZmZmZmYiIHN0cm9rZS13aWR0aD0iMjAiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIvPjxwYXRoIGQ9Ik0xMDUuNTUwMDksMTMwLjQ3Mjk3YzAsMCAxNy43NDUwMiwyMC44MDM2NCAxNy40ODQ4NCw0OS44Mjc3OWMtMC4zMTIyMSwzNC44MTM1OCAtMjAuNDQwNDQsNTAuNjIyODkgLTIwLjQ0MDQ0LDUwLjYyMjg5IiBkYXRhLXBhcGVyLWRhdGE9InsmcXVvdDtpbmRleCZxdW90OzpudWxsfSIgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjZmZmZmZmIiBzdHJva2Utd2lkdGg9IjIwIiBzdHJva2UtbGluZWNhcD0icm91bmQiLz48cGF0aCBkPSJNMjkxLjE3Mzk0LDIzNC4yNzY3OWMwLDAgLTc5LjIzNTk2LC01OC41Njg2NSAtODQuOTgzNzYsLTY0LjY0MTE1Yy0xLjUyNjcxLC0xLjYxMzA5IC03LjQxNjA1LC03Ljk5OTg4IC03LjMwMzY1LC0yMS40MjgwNmMwLjE0MjU4LC0xNy4xNDY2MSAxMy40NjA0NCwtMjUuNjc0MTMgMjguMzU5MTQsLTI1LjMxNTA5YzE2LjIwNjg2LDAuMzkwMjYgMjguNTU2ODcsMTEuNDA2MSAyOC4xODIyMiwyNS43MDMyN2MtMC41NjE5OCwyMS4zNjQ1OCAtMTIuNzk5NiwzMy4xMzU5NiAtMzEuNDI5MjEsMzIuMDU0NjdjLTE2LjQ1MDM4LC0wLjk1NDMyIC0yNy45MTY4NCwxOC4zOTc1NCAtMjcuMDA3MjcsMzAuMzI1MDNjMS4yOTM1OSwxNi45NjU1MyAxMi44MzcwNiwyNi4yMDkwNSAyMy41MDIxOCwyNi4xNDI0NGM0NC44MzU1NCwtMC4yODA5OSA2MS42MzE0NCwtNTMuMjUyNzQgNjEuNjMxNDQsLTUzLjI1Mjc0IiBmaWxsPSJub25lIiBzdHJva2Utb3BhY2l0eT0iMC4xNSIgc3Ryb2tlPSIjMDAwMDAwIiBzdHJva2Utd2lkdGg9IjM1IiBzdHJva2UtbGluZWNhcD0icm91bmQiLz48cGF0aCBkPSJNMjkxLjE3Mzk0LDIzNC4yNzY3OWMwLDAgLTc5LjIzNTk2LC01OC41Njg2NSAtODQuOTgzNzYsLTY0LjY0MTE1Yy0xLjUyNjcxLC0xLjYxMzA5IC03LjQxNjA1LC03Ljk5OTg4IC03LjMwMzY1LC0yMS40MjgwNmMwLjE0MjU4LC0xNy4xNDY2MSAxMy40NjA0NCwtMjUuNjc0MTMgMjguMzU5MTQsLTI1LjMxNTA5YzE2LjIwNjg2LDAuMzkwMjYgMjguNTU2ODcsMTEuNDA2MSAyOC4xODIyMiwyNS43MDMyN2MtMC41NjE5OCwyMS4zNjQ1OCAtMTIuNzk5NiwzMy4xMzU5NiAtMzEuNDI5MjEsMzIuMDU0NjdjLTE2LjQ1MDM4LC0wLjk1NDMyIC0yNy45MTY4NCwxOC4zOTc1NCAtMjcuMDA3MjcsMzAuMzI1MDNjMS4yOTM1OSwxNi45NjU1MyAxMi44MzcwNiwyNi4yMDkwNSAyMy41MDIxOCwyNi4xNDI0NGM0NC44MzU1NCwtMC4yODA5OSA2MS42MzE0NCwtNTMuMjUyNzQgNjEuNjMxNDQsLTUzLjI1Mjc0IiBmaWxsPSJub25lIiBzdHJva2U9IiNmZmZmZmYiIHN0cm9rZS13aWR0aD0iMjAiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIvPjxnIGZpbGw9Im5vbmUiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCI+PHBhdGggZD0iTTEwOC44Mzg3MiwyNDYuOTI3NTdoNDUuMTIyNzdNMTMxLjQwMTE0LDIyNC4zNjcyM3Y0NS4xMjE3MyIgc3Ryb2tlLW9wYWNpdHk9IjAuMTUiIHN0cm9rZT0iIzAwMDAwMCIgc3Ryb2tlLXdpZHRoPSI0NSIvPjxwYXRoIGQ9Ik0xMDguODM4NzIsMjQ2LjkyNzU3aDQ1LjEyMjc3TTEzMS40MDExNCwyMjQuMzY3MjN2NDUuMTIxNzMiIHN0cm9rZT0iI2ZmZmZmZiIgc3Ryb2tlLXdpZHRoPSIyNSIvPjwvZz48L2c+PC9nPjwvZz48L3N2Zz48IS0tcm90YXRpb25DZW50ZXI6Mjk5LjgyODczOTk5OTk5OTk6MTg1Ljc1OTc2LS0+";
+
+let openCaseSensitive=false;
+
+class VarAndList {
+  constructor(runtime) {
+    this.runtime = runtime;
+    this._formatMessage = runtime.getFormatMessage({
+      'zh-cn': {
+        'qxsckvarandlist.name': '变量与列表',
+
+        'qxsckvarandlist.open': '打开',
+        'qxsckvarandlist.close': '关闭',
+
+        'qxsckvarandlist.haveVar': '有变量 [VAR] 吗？',
+        'qxsckvarandlist.getVar': '[VAR] 的值',
+        'qxsckvarandlist.setVar': '将变量 [VAR] 的值设置为 [VALUE]',
+        'qxsckvarandlist.seriVarsToJson': '将以 [START] 为开头的所有变量转换为json',
+
+        'qxsckvarandlist.openCaseSensitive': '[CASE] 大小写敏感',
+        'qxsckvarandlist.haveList': '有列表 [LIST] 吗？',
+        'qxsckvarandlist.length': '列表 [LIST] 的长度',
+        'qxsckvarandlist.getList': '列表 [LIST] 的值',
+        'qxsckvarandlist.getValueOfList': '列表 [LIST] 的第 [INDEX] 项',
+        'qxsckvarandlist.seriListsToJson': '将以 [START] 为开头的所有列表转换为json',
+        'qxsckvarandlist.clearList': '清空列表 [LIST]',
+        'qxsckvarandlist.deleteOfList': '删除列表 [LIST] 的第 [INDEX] 项',
+        'qxsckvarandlist.addValueInList': '在列表 [LIST] 末尾添加 [VALUE]',
+        'qxsckvarandlist.addListToList': '在列表 [LIST] 末尾添加列表 [LIST2]',
+        'qxsckvarandlist.replaceOfList': '替换列表 [LIST] 的第 [INDEX] 项为 [VALUE]',
+        'qxsckvarandlist.getIndexOfList': '列表 [LIST] 中第一个 [VALUE] 的位置',
+        'qxsckvarandlist.getIndexesOfList': '列表 [LIST] 中所有 [VALUE] 的位置',
+        'qxsckvarandlist.getCountsOfList': '列表 [LIST] 中 [VALUE] 的数量',
+        'qxsckvarandlist.listContains': '列表 [LIST] 包括 [VALUE] 吗？',
+        'qxsckvarandlist.copyList': '将列表 [LIST1] 复制到列表 [LIST2]',
+        'qxsckvarandlist.reverseList': '反转列表 [LIST]',
+      },
+      en: {
+        'qxsckvarandlist.name': 'var and list',
+
+        'qxsckvarandlist.open': 'open',
+        'qxsckvarandlist.close': 'close',
+
+        'qxsckvarandlist.haveVar': 'have [VAR] ?',
+        'qxsckvarandlist.getVar': 'value of [VAR]',
+        'qxsckvarandlist.setVar': 'set the value of [VAR] to [VALUE]',
+        'qxsckvarandlist.seriVarsToJson': 'convert all variables starting with [START] to json',
+
+        'qxsckvarandlist.openCaseSensitive': '[CASE] case sensitive',
+        'qxsckvarandlist.haveList': 'have list [LIST] ?',
+        'qxsckvarandlist.length': 'length of list [LIST]',
+        'qxsckvarandlist.getList': 'value of list [LIST]',
+        'qxsckvarandlist.getValueOfList': 'item [INDEX] of list [LIST]',
+        'qxsckvarandlist.seriListsToJson': 'convert all lists starting with [START] to json',
+        'qxsckvarandlist.clearList': 'delete all of list [LIST]',
+        'qxsckvarandlist.deleteOfList': 'delete [INDEX] of list [LIST]',
+        'qxsckvarandlist.addValueInList': 'add [VALUE] to list [LIST]',
+        'qxsckvarandlist.addListInList': 'add list [LIST2] to list [LIST]',
+        'qxsckvarandlist.replaceOfList': 'replace item [INDEX] of list [LIST] with [VALUE]',
+        'qxsckvarandlist.getIndexOfList': 'first index of list [VALUE] in list [LIST]',
+        'qxsckvarandlist.getIndexesOfList': 'indexes of list [LIST] in [VALUE]',
+        'qxsckvarandlist.getCountsOfList': 'number of list [LIST] in [VALUE]',
+        'qxsckvarandlist.listContains': 'list [LIST] have [VALUE] ?',
+        'qxsckvarandlist.copyList': 'copy list [LIST1] to list [LIST2]',
+        'qxsckvarandlist.reverseList': 'reverse lsit [LIST]',
+      },
+    });
+  }
+  formatMessage(id) {
+      return this._formatMessage({
+        id,
+        default: id,
+        description: id,
+      })
+  }
+
+  getInfo() {
+    return {
+      id:'qxsckvarandlist',
+      name: this.formatMessage('qxsckvarandlist.name'),
+      color1: '#ed6b00',
+      color2: '#ed6b00',
+      blockIconURI: Icon,
+      menuIconURI: Icon,
+      blocks: [
+        //command,reporter,Boolean,hat
+        {
+          opcode:'haveVar',
+          blockType: 'Boolean',
+          text: this.formatMessage('qxsckvarandlist.haveVar'),
+          arguments: {
+            VAR: {
+              type: 'string',
+              defaultValue:'variable'
+            },
+          }
+        },
+        {
+          opcode:'getVar',
+          blockType: 'reporter',
+          text: this.formatMessage('qxsckvarandlist.getVar'),
+          arguments: {
+            VAR: {
+              type: 'string',
+              defaultValue:'variable'
+            },
+          }
+        },
+        {
+          opcode:'setVar',
+          blockType: 'command',
+          text: this.formatMessage('qxsckvarandlist.setVar'),
+          arguments: {
+            VAR: {
+              type: 'string',
+              defaultValue:'variable'
+            },
+            VALUE: {
+              type: 'string',
+              defaultValue:'value'
+            },
+          }
+        },
+        {
+          opcode:'seriVarsToJson',
+          blockType: 'reporter',
+          text: this.formatMessage('qxsckvarandlist.seriVarsToJson'),
+          arguments: {
+            START: {
+              type: 'string',
+              defaultValue:'variable'
+            },
+          }
+        },
+
+        '---',
+
+        {
+          opcode:'openCaseSensitive',
+          blockType: 'command',
+          text: this.formatMessage('qxsckvarandlist.openCaseSensitive'),
+          arguments: {
+            CASE: {
+              type: 'string',
+              menu: 'openCaseSensitive.List',
+            },
+          }
+        },
+        {
+          opcode:'haveList',
+          blockType: 'Boolean',
+          text: this.formatMessage('qxsckvarandlist.haveList'),
+          arguments: {
+            LIST: {
+              type: 'string',
+              defaultValue:'list'
+            },
+          }
+        },
+        {
+          opcode:'length',
+          blockType: 'reporter',
+          text: this.formatMessage('qxsckvarandlist.length'),
+          arguments: {
+            LIST: {
+              type: 'string',
+              defaultValue:'list'
+            }
+          }
+        },
+        {
+          opcode:'getList',
+          blockType: 'reporter',
+          text: this.formatMessage('qxsckvarandlist.getList'),
+          arguments: {
+            LIST: {
+              type: 'string',
+              defaultValue:'list'
+            },
+          }
+        },
+        {
+          opcode:'getValueOfList',
+          blockType: 'reporter',
+          text: this.formatMessage('qxsckvarandlist.getValueOfList'),
+          arguments: {
+            LIST: {
+              type: 'string',
+              defaultValue:'list'
+            },
+            INDEX: {
+              type: 'string',
+              defaultValue:'1'
+            }
+          }
+        },
+        {
+          opcode:'seriListsToJson',
+          blockType: 'reporter',
+          text: this.formatMessage('qxsckvarandlist.seriListsToJson'),
+          arguments: {
+            START: {
+              type: 'string',
+              defaultValue:'list'
+            },
+          }
+        },
+        {
+          opcode:'clearList',
+          blockType: 'command',
+          text: this.formatMessage('qxsckvarandlist.clearList'),
+          arguments: {
+            LIST: {
+              type: 'string',
+              defaultValue:'list'
+            },
+          }
+        },
+        {
+          opcode:'deleteOfList',
+          blockType: 'command',
+          text: this.formatMessage('qxsckvarandlist.deleteOfList'),
+          arguments: {
+            LIST: {
+              type: 'string',
+              defaultValue:'list'
+            },
+            INDEX: {
+              type: 'string',
+              defaultValue:'1'
+            }
+          }
+        },
+        {
+          opcode:'addValueInList',
+          blockType: 'command',
+          text: this.formatMessage('qxsckvarandlist.addValueInList'),
+          arguments: {
+            LIST: {
+              type: 'string',
+              defaultValue:'list'
+            },
+            VALUE: {
+              type: 'string',
+              defaultValue:'value'
+            },
+          }
+        },
+        {
+          opcode:'addListToList',
+          blockType: 'command',
+          text: this.formatMessage('qxsckvarandlist.addListToList'),
+          arguments: {
+            LIST: {
+              type: 'string',
+              defaultValue:'list'
+            },
+            LIST2: {
+              type: 'string',
+              defaultValue:'["a","a"]'
+            },
+          }
+        },
+        {
+          opcode:'replaceOfList',
+          blockType: 'command',
+          text: this.formatMessage('qxsckvarandlist.replaceOfList'),
+          arguments: {
+            LIST: {
+              type: 'string',
+              defaultValue:'list'
+            },
+            INDEX: {
+              type: 'string',
+              defaultValue:'1'
+            },
+            VALUE: {
+              type: 'string',
+              defaultValue:'thing'
+            }
+          }
+        },
+        {
+          opcode:'getIndexOfList',
+          blockType: 'reporter',
+          text: this.formatMessage('qxsckvarandlist.getIndexOfList'),
+          arguments: {
+            LIST: {
+              type: 'string',
+              defaultValue:'list'
+            },
+            VALUE: {
+              type: 'string',
+              defaultValue:'thing'
+            }
+          }
+        },
+        {
+          opcode:'getIndexesOfList',
+          blockType: 'reporter',
+          text: this.formatMessage('qxsckvarandlist.getIndexesOfList'),
+          arguments: {
+            LIST: {
+              type: 'string',
+              defaultValue:'list'
+            },
+            VALUE: {
+              type: 'string',
+              defaultValue:'thing'
+            }
+          }
+        },
+        {
+          opcode:'getCountsOfList',
+          blockType: 'reporter',
+          text: this.formatMessage('qxsckvarandlist.getCountsOfList'),
+          arguments: {
+            LIST: {
+              type: 'string',
+              defaultValue:'list'
+            },
+            VALUE: {
+              type: 'string',
+              defaultValue:'thing'
+            }
+          }
+        },
+        {
+          opcode:'listContains',
+          blockType: 'Boolean',
+          text: this.formatMessage('qxsckvarandlist.listContains'),
+          arguments: {
+            LIST: {
+              type: 'string',
+              defaultValue:'list'
+            },
+            VALUE: {
+              type: 'string',
+              defaultValue:'thing'
+            }
+          }
+        },
+        {
+          opcode:'copyList',
+          blockType: 'command',
+          text: this.formatMessage('qxsckvarandlist.copyList'),
+          arguments: {
+            LIST1: {
+              type: 'string',
+              defaultValue:'list1'
+            },
+            LIST2: {
+              type: 'string',
+              defaultValue:'list2'
+            }
+          }
+        },
+        {
+          opcode:'reverseList',
+          blockType: 'command',
+          text: this.formatMessage('qxsckvarandlist.reverseList'),
+          arguments: {
+            LIST: {
+              type: 'string',
+              defaultValue:'list'
+            },
+          }
+        },
+      ],
+      menus: {
+        'openCaseSensitive.List':[
+          {
+            text: this.formatMessage("qxsckvarandlist.open"),
+            value: 'open'
+          },
+          {
+            text: this.formatMessage("qxsckvarandlist.close"),
+            value: 'close'
+          },
+        ],
+      }
+    };
+  }
+  findAllVar() {
+    let list = [],temp;
+    try{
+      if(this.runtime._editingTarget.isStage){
+        temp = this.runtime._stageTarget.variables;
+
+        Object.keys(temp).forEach(obj => {
+          if (temp[obj].type === '') list.push({text: temp[obj].name,value: temp[obj].id});
+        });
+      }else{
+        temp = this.runtime._editingTarget.variables;
+        Object.keys(temp).forEach(obj => {
+          if (temp[obj].type === '') list.push({text: temp[obj].name,value: temp[obj].id});
+        });
+      }
+    }catch(e){}
+    if (list.length === 0) list.push({text: `-`,value: 'empty'});
+    return list;
+  }
+
+  findAllList() {
+    let list = [],temp;
+    try {
+      if(this.runtime._editingTarget.isStage){
+        temp = this.runtime._stageTarget.variables
+        Object.keys(temp).forEach(obj => {
+          if (temp[obj].type === 'list') list.push({text: temp[obj].name,value: temp[obj].id});
+        });
+      }else{
+        temp = this.runtime._editingTarget.variables
+        Object.keys(temp).forEach(obj => {
+          if (temp[obj].type === 'list') list.push({text: temp[obj].name,value: temp[obj].id});
+        });
+      }
+    }catch(e){}
+    if (list.length === 0) list.push({text: `-`,value: 'empty'});
+    return list;
+  }
+
+  haveVar(args, util) {
+    const variable = util.target.lookupVariableByNameAndType(String(args.VAR), '');
+    return variable ? true : false;
+  }
+  getVar(args, util) {
+    const variable = util.target.lookupVariableByNameAndType(String(args.VAR), '');
+    return variable ? variable.value :'';
+  }
+  setVar(args, util) {
+    const variable = util.target.lookupVariableByNameAndType(String(args.VAR), '');
+    if (variable) {
+      variable.value = args.VALUE;
+    }
+  }
+  seriVarsToJson(args, util) {
+    const start = String(args.START);
+    const serialized = {};
+    for (const variable of Object.values(util.runtime.getTargetForStage().variables)) {
+      if (variable.type === '' && variable.name.startsWith(start)) {
+        serialized[variable.name.replace(start, '')] = variable.value;
+      }
+    }
+    for (const variable of Object.values(util.target.variables)) {
+      if (variable.type === '' && variable.name.startsWith(start)) {
+        serialized[variable.name.replace(start, '')] = variable.value;
+      }
+    }
+    return JSON.stringify(serialized);
+  }
+
+  openCaseSensitive(args){
+    openCaseSensitive=(String(args.CASE)==='open'?true:false);
+  }
+  haveList(args, util) {
+    const variable = util.target.lookupVariableByNameAndType(String(args.LIST), 'list');
+    return variable ? true : false;
+  }
+  length(args, util) {
+    /** @type {VM.ListVariable} */
+    const variable = util.target.lookupVariableByNameAndType(String(args.LIST), 'list');
+    if (variable) {
+      return variable.value.length;
+    }
+    return 0;
+  }
+  getList(args, util) {
+    const variable = util.target.lookupVariableByNameAndType(String(args.LIST), 'list');
+    return variable ? variable.value.toString() :'';
+  }
+  getValueOfList(args, util) {
+    const variable = util.target.lookupVariableByNameAndType(String(args.LIST), 'list');
+    if (!variable) return 0;
+    const index = ListIndex(args.INDEX, variable.value.length, false);
+    if (index === 'INVALID') return '';
+    return variable.value[index - 1];
+  }
+  seriListsToJson(args, util) {
+    const start = String(args.START);
+    const serialized = {};
+    for (const variable of Object.values(util.runtime.getTargetForStage().variables)) {
+      if (variable.type === 'list' && variable.name.startsWith(start)) {
+        serialized[variable.name.replace(start, '')] = variable.value;
+      }
+    }
+    for (const variable of Object.values(util.target.variables)) {
+      if (variable.type === 'list' && variable.name.startsWith(start)) {
+        serialized[variable.name.replace(start, '')] = variable.value;
+      }
+    }
+    return JSON.stringify(serialized);
+  }
+  clearList(args, util) {
+    /** @type {VM.ListVariable} */
+    const variable = util.target.lookupVariableByNameAndType(String(args.LIST), 'list');
+    if (variable) {
+      variable.value = [];
+    }
+  }
+  deleteOfList(args, util) {
+    /** @type {VM.ListVariable} */
+    const variable = util.target.lookupVariableByNameAndType(String(args.LIST), 'list');
+    if (variable) {
+      const index = ListIndex(args.INDEX, variable.value.length, true);
+      if (index === 'ALL') {
+        variable.value = [];
+      } else if (index !== 'INVALID') {
+        variable.value.splice(index - 1, 1);
+        variable._monitorUpToDate = false;
+      }
+    }
+  }
+  addValueInList(args, util) {
+    /** @type {VM.ListVariable} */
+    const variable = util.target.lookupVariableByNameAndType(String(args.LIST), 'list');
+    if (variable) {
+      variable.value.push(args.VALUE);
+      variable._monitorUpToDate = false;
+    }
+  }
+  addListToList(args, util) {
+    /** @type {VM.ListVariable} */
+    const variable = util.target.lookupVariableByNameAndType(String(args.LIST), 'list'),list2=String(args.LIST2);
+    if (variable) {
+      try {
+        var arr = JSON.parse(list2);
+        for (var i = 0; i < arr.length; i++) {
+          variable.value.push(arr[i]);
+        }
+        variable._monitorUpToDate = false;
+      } catch (error) {
+        console.log('error:', error);
+      }
+    }
+  }
+  replaceOfList(args, util) {
+    /** @type {VM.ListVariable} */
+    const variable = util.target.lookupVariableByNameAndType(String(args.LIST), 'list');
+    if (variable) {
+      const index = ListIndex(args.INDEX, variable.value.length, false);
+      if (index !== 'INVALID') {
+        variable.value[index - 1] = args.VALUE;
+        variable._monitorUpToDate = false;
+      }
+    }
+  }
+  getIndexOfList(args, util) {
+    /** @type {VM.ListVariable} */
+    const variable = util.target.lookupVariableByNameAndType(String(args.LIST), 'list');
+    const value = args.VALUE;
+    let flag=openCaseSensitive;
+    if (variable) {
+      for (var i = 0; i < variable.value.length; i++) {
+        if(!flag){
+          if (Scratch.Cast.compare(variable.value[i], value) === 0) return i + 1;
+        }else{
+          if (String(variable.value[i]) === String(value)) return i + 1;
+        }
+      }
+    }
+    return 0;
+  }
+  getIndexesOfList(args, util) {
+    /** @type {VM.ListVariable} */
+    const variable = util.target.lookupVariableByNameAndType(String(args.LIST), 'list');
+    const value = args.VALUE;
+    let flag=openCaseSensitive;
+    if (variable) {
+      var indexes = [];
+      for (var i = 0; i < variable.value.length; i++) {
+        if(!flag){
+          if (Scratch.Cast.compare(variable.value[i], value) === 0) indexes.push(i + 1);
+        }else{
+          if (String(variable.value[i]) === String(value)) indexes.push(i + 1);
+        }
+      }
+      if (indexes.length > 0) return indexes.toString();
+    }
+    return '';
+  }
+  getCountsOfList(args, util) {
+    /** @type {VM.ListVariable} */
+    const variable = util.target.lookupVariableByNameAndType(String(args.LIST), 'list');
+    const value = args.VALUE;
+    let flag=openCaseSensitive;
+    if (variable) {
+      var indexes = [];
+      for (var i = 0; i < variable.value.length; i++) {
+        if(!flag){
+          if (Scratch.Cast.compare(variable.value[i], value) === 0) indexes.push(i + 1);
+        }else{
+          if (String(variable.value[i]) === String(value)) indexes.push(i + 1);
+        }
+      }
+      return indexes.length;
+    }
+    return 0;
+  }
+  listContains(args, util) {
+    /** @type {VM.ListVariable} */
+    const variable = util.target.lookupVariableByNameAndType(String(args.LIST), 'list');
+    const value = args.VALUE;
+    let flag=openCaseSensitive;
+    if (variable) {
+      for (var i = 0;i < variable.value.length;i++) {
+        if(!flag){
+          if (Scratch.Cast.compare(variable.value[i], value) === 0) return true;
+        }else{
+          if (String(variable.value[i]) === String(value)) return true;
+        }
+      }
+      return false;
+    }
+    return false;
+  }
+  copyList(args, util) {
+    /** @type {VM.ListVariable} */
+    const list1 = util.target.lookupVariableByNameAndType(String(args.LIST1), 'list');
+    const list2 = util.target.lookupVariableByNameAndType(String(args.LIST2), 'list');
+    if (list1 && list2) {
+      list2.value = list1.value.slice();
+    }
+  }
+  reverseList(args, util) {
+    /** @type {VM.ListVariable} */
+    const variable = util.target.lookupVariableByNameAndType(String(args.LIST), 'list');
+    if (variable) {
+      var list=variable.value.slice();
+      list.reverse();
+      variable.value=list;
+      variable._monitorUpToDate = false;
+    }
+  }
+}
+
+window.tempExt = {
+  Extension: VarAndList,
+  info: {
+    name: 'qxsckvarandlist.name',
+    description: 'qxsckvarandlist.description',
+    extensionId: 'qxsckvarandlist',
+    iconURL: insetIcon,
+    insetIconURL: Icon,
+    featured: true,
+    disabled: false,
+    collaborator: 'CK七星松@CCW'
+  },
+  l10n: {
+    'zh-cn': {
+      'qxsckvarandlist.name':'变量与列表',
+      'qxsckvarandlist.description':'一些关于变量与列表的积木'
+    },
+    'en': {
+      'qxsckvarandlist.name':'Variable and list',
+      'qxsckvarandlist.description':'some blocks about variables and lists.'
+    }
+  },
+}


### PR DESCRIPTION
操作原版变量与列表的拓展，部分积木与TurboWarp中的“变量与列表”拓展兼容，另外添加了一些新的积木，未来会有更多的积木加入

an extension to operate the Scratch variables and lists, some blocks are compatible with "Variable and list" extension in TurboWarp,and add some new blocks,more blocks will be add in future